### PR TITLE
Update README to remove obsolete master_design bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ This repository contains the complete draft structure, technical specification, 
 - `original_docs/`: Human-readable documentation from GPT/Gemini/GD.
 - `structured_yaml/`: Structured YAML data following `master_schema_v1.yaml`.
 - `structured_yaml/validated_yaml/`: YAML conforming to schema.
-- `master_design/`: Design-level visualizations and protocol blueprints.
 
 ## 🧠 Motivation
 


### PR DESCRIPTION
## Summary
- remove outdated reference to `master_design/` directory

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684f40f2e98483338471c5afd98262bd