### PR TITLE
Improve README guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This repository contains the complete draft structure, technical specification, 
 ## 📂 Repository Structure
 
 - `original_docs/`: Human-readable documentation from GPT/Gemini/GD.
-- `structured_yaml/`: Structured YAML data following `master_schema_v1.yaml`.
-- `structured_yaml/validated_yaml/`: YAML conforming to schema.
+- `structured_yaml/`: Structured YAML data following `master_schema_v1.yaml`. All YAML files should conform to this schema.
+- `structured_yaml/validated_yaml/`: YAML validated against `master_schema_v1.yaml`.
 - `master_design/`: Design-level visualizations and protocol blueprints.
 
 ## 🧠 Motivation

--- a/structured_yaml/README.md
+++ b/structured_yaml/README.md
@@ -1,8 +1,10 @@
 # structured_yaml
 
 このディレクトリは AI‑TCP関連の構造化データ(YAML)を格納します。
+すべてのYAMLファイルは`master_schema_v1.yaml`で定義されるスキーマに準拠します。
 
 ## validated_yaml/
+スキーマ検証を完了したファイルを配置します。
 - ai_tcp_timeline.yaml – 制定経緯タイムライン（構文・内容確認済）
 - ai_tcp_poc_design.yaml – PoC設計概要（構文OK、構造要整形）
 
@@ -13,5 +15,5 @@
 
 ## 今後の手順
 1. 構造要検討ファイルはフォーマット・内容のYAML化を継続
-2. `master_schema_v1.yaml` を作成・設置
+2. `master_schema_v1.yaml` に基づき各ファイルを検証
 3. 統合された構造をCodex/GDで検証・調整


### PR DESCRIPTION
## Summary
- reference the master schema in `validated_yaml/` description
- clarify that all YAML files should conform to the schema
- update future steps so the schema is used for validation instead of creation

## Testing
- `python3 - <<'PY'
import yaml, sys, glob
for path in glob.glob('structured_yaml/**/*.yaml', recursive=True):
    try:
        with open(path) as f:
            yaml.safe_load(f)
    except Exception as e:
        print('YAML parse error in', path, ':', e)
PY` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684f42c381d08333aa596d1b5deb1a7f