### PR TITLE
Fix README repo structure bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains the complete draft structure, technical specification, 
 - `original_docs/`: Human-readable documentation from GPT/Gemini/GD.
 - `structured_yaml/`: Structured YAML data following `master_schema_v1.yaml`.
 - `structured_yaml/validated_yaml/`: YAML conforming to schema.
-- `master_design/`: Design-level visualizations and protocol blueprints.
+- `structured_yaml/docs/`: Documentation with embedded YAML metadata.
 
 ## 🧠 Motivation
 


### PR DESCRIPTION
## Summary
- replace invalid `master_design/` bullet with `structured_yaml/docs/`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f42c4579c83339141ee3b678933c9