### PR TITLE
Add docs overview and RFC skeleton

### DIFF
--- a/docs/AI-TCP_RFC.md
+++ b/docs/AI-TCP_RFC.md
@@ -1,0 +1,51 @@
+---
+title: AI-TCP Protocol Specification
+version: 0.0
+status: draft
+language: en
+---
+
+# AI-TCP Protocol Specification (Draft)
+
+## 1. Abstract
+
+AI-TCP provides a neutral and traceable transport for inter‑LLM communication. This draft outlines the initial design goals and message structure in preparation for a formal IETF submission.
+
+## 2. Introduction
+
+Large language models increasingly interact as autonomous agents. AI‑TCP defines a standard session format so that these models can exchange signed semantic payloads over existing TCP/IP networks.
+
+## 3. Terminology
+
+- **AI Node**: an LLM or agent participating in AI‑TCP.
+- **AITCPSession**: a single, authenticated exchange of one or more messages.
+
+## 4. Protocol Overview
+
+### 4.1 Session Layer
+
+Establishes unique session identifiers, timestamps, and optional TLS parameters.
+
+### 4.2 Payload Layer
+
+Structured messages encoded in model‑native text or binary formats. Each payload is signed and includes a trace header.
+
+### 4.3 Security Layer
+
+Supports end‑to‑end encryption and non‑repudiation through digital signatures.
+
+## 5. Security Considerations
+
+Implementations must protect private keys and validate all signatures. Replay attacks should be mitigated via unique session IDs and timestamps.
+
+## 6. IANA Considerations
+
+No IANA actions are requested in this draft.
+
+## 7. Acknowledgements
+
+Developed collaboratively by multi‑agent teams and human reviewers.
+
+## 8. License
+
+This work is released under CC0‑1.0.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,13 @@
+# Documentation Overview
+
+This directory contains working drafts and reference materials for the AI-TCP project.
+Each document follows a lightweight RFC style with YAML front matter when appropriate.
+
+## Contents
+
+- `AI-TCP_RFC.md` – Skeleton RFC describing the AI‑TCP protocol using IETF style sections.
+- `direct_mental_care.md` – RFC‑DMC‑0001 outlining a mental health care system built on AI‑TCP.
+- `poc_design/` – Proof‑of‑concept YAML files for prototypes and reference data.
+- `templates/` – Editable templates for new RFC drafts.
+
+Use these materials as a starting point for future AI‑TCP standards and related proposals.

--- a/docs/templates/ai_tcp_rfc_template.md
+++ b/docs/templates/ai_tcp_rfc_template.md
@@ -1,0 +1,40 @@
+---
+title: RFC Draft: <Insert Title Here>
+version: 0.0
+status: draft
+language: en
+---
+
+# RFC Draft: <Insert Descriptive Heading>
+
+## 1. Abstract
+
+Provide a concise summary of the proposal.
+
+## 2. Motivation
+
+Explain why this RFC is necessary and what problem it addresses.
+
+## 3. Protocol Overview
+
+Describe the architecture and main components of the proposed extension or use of AI‑TCP.
+
+## 4. Detailed Specification
+
+Present message formats, state machines, or algorithms in detail.
+
+## 5. Security Considerations
+
+Discuss potential risks and how they are mitigated.
+
+## 6. IANA Considerations
+
+List any required registrations or state that none are needed.
+
+## 7. Acknowledgements
+
+Recognize contributors and prior art.
+
+## 8. License
+
+This work is released under CC0‑1.0.


### PR DESCRIPTION
## Summary
- outline the purpose and layout of the `docs/` directory
- add an initial AI‑TCP protocol RFC draft
- provide a template file for new RFCs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f5a309e2c83339537e5035f1bd4a2