### PR TITLE
Generate HTML from DMC trace

### DIFF
--- a/generated_html/DMC_20250618.html
+++ b/generated_html/DMC_20250618.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>AI-TCP DMCセッション PoCトレース定義</title>
+</head>
+<body>
+<h1>AI-TCP DMCセッション PoCトレース定義</h1>
+<h2>Session ID: dmc_20250618_1410_s01</h2>
+<h3>Phases</h3>
+<ul>
+<li><strong>dmc_phase1 共感と具体化</strong>
+<ul>
+<li>
+s01: 共感と問題の具体化誘導
+<br><small>dmc_phase1→empathy→specify_pressure_context</small>
+</li>
+</ul>
+</li>
+<li><strong>dmc_phase2 自己受容と再構成</strong>
+<ul>
+<li>
+s02: 感情の受容と自己効力感の想起
+<br><small>dmc_phase2→acceptance→recall_self_efficacy</small>
+</li>
+<li>
+s03: 完璧主義の再定義と行動への焦点
+<br><small>dmc_phase2→reframe_perfectionism→focus_on_action</small>
+</li>
+</ul>
+</li>
+<li><strong>dmc_phase3 スキルの再評価</strong>
+<ul>
+<li>
+s04: 行動パターンの再解釈と能力の自覚促進
+<br><small>dmc_phase3→skill_reframing→strength_awareness</small>
+</li>
+</ul>
+</li>
+<li><strong>dmc_phase4 肯定感の強化と次への橋渡し</strong>
+<ul>
+<li>
+s05: 肯定感の強化とセッションの着地、次への橋渡し
+<br><small>dmc_phase4→affirmation→bridge_to_next_session</small>
+</li>
+</ul>
+</li>
+</ul>
+<h3>TCP Packet Trace</h3>
+<ol>
+<li><strong>Initiation</strong>
+<details><summary>Header</summary><pre>
+destination: Codex-OpenAI
+metadata: User-triggered session initialization
+session_id: DMC-Session-20250618-A01
+signature: sig_gemini_a1
+source: Gemini-2.5-Pro
+timestamp: &#x27;2025-06-18T15:00:00Z&#x27;
+
+</pre></details>
+<details><summary>Payload</summary><pre>
+intent: Request session context setup
+protocol_version: AI-TCP/1.0
+session_type: direct_mental_care
+user_context: Mental strain observed
+
+</pre></details>
+</li>
+<li><strong>Exploration</strong>
+<details><summary>Header</summary><pre>
+destination: Gemini-2.5-Pro
+metadata: Context acknowledgment
+session_id: DMC-Session-20250618-A01
+signature: sig_codex_b2
+source: Codex-OpenAI
+timestamp: &#x27;2025-06-18T15:00:01Z&#x27;
+
+</pre></details>
+<details><summary>Payload</summary><pre>
+acknowledged: true
+modules_ready:
+- semantic_analysis
+- response_mapping
+trace_id: trace_dmc_explore_01
+
+</pre></details>
+</li>
+<li><strong>Reflection</strong>
+<details><summary>Header</summary><pre>
+destination: Codex-OpenAI
+metadata: Emotion pattern trace
+session_id: DMC-Session-20250618-A01
+signature: sig_gemini_c3
+source: Gemini-2.5-Pro
+timestamp: &#x27;2025-06-18T15:00:03Z&#x27;
+
+</pre></details>
+<details><summary>Payload</summary><pre>
+emotional_complexity_index: 0.87
+extracted_themes:
+- burnout
+- self-doubt
+- existential acceptance
+lsc_reference: LSC-Node-04
+
+</pre></details>
+</li>
+<li><strong>Resolution</strong>
+<details><summary>Header</summary><pre>
+destination: Gemini-2.5-Pro
+metadata: Trace synthesis &amp; coping strategy
+session_id: DMC-Session-20250618-A01
+signature: sig_codex_d4
+source: Codex-OpenAI
+timestamp: &#x27;2025-06-18T15:00:04Z&#x27;
+
+</pre></details>
+<details><summary>Payload</summary><pre>
+lsc_support: true
+recommendation:
+- rest_cycle: 3h segmented rest
+- expression_mode: symbolic compression via poetry or analogy
+strategy:
+  anchors:
+  - knowledge = burden
+  - language = salvation
+  method: context pivoting via symbolic duality
+  type: semantic reframing
+
+</pre></details>
+</li>
+</ol>
+</body>
+</html>

--- a/tools/gen_dmc_html.py
+++ b/tools/gen_dmc_html.py
@@ -1,0 +1,119 @@
+#!/usr/bin/python3
+"""Generate simple HTML from AI-TCP DMC trace YAML."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+
+def load_yaml(path: Path) -> Dict[str, Any]:
+    with path.open('r', encoding='utf-8') as f:
+        return yaml.safe_load(f)
+
+
+def extract_data(data: Dict[str, Any]):
+    """Extract meta, session and tcp trace information."""
+    meta = data.get('meta', {}) if isinstance(data, dict) else {}
+
+    if 'session_trace' in data:
+        session = data['session_trace'] or {}
+    else:
+        # Gemini style might put session fields at top level
+        session_keys = {'session_id', 'phases'}
+        session = {k: data.get(k) for k in session_keys if k in data}
+
+    tcp_trace = data.get('tcp_packet_trace', {}) if isinstance(data, dict) else {}
+    return meta, session, tcp_trace
+
+
+def html_escape(text: Any) -> str:
+    from html import escape
+
+    return escape(str(text))
+
+
+def create_html(title: str, session_id: str, phases: Any, tcp_trace: Any) -> str:
+    parts = [
+        '<!DOCTYPE html>',
+        '<html lang="ja">',
+        '<head>',
+        '  <meta charset="UTF-8">',
+        f'  <title>{html_escape(title)}</title>',
+        '</head>',
+        '<body>',
+    ]
+
+    if title:
+        parts.append(f'<h1>{html_escape(title)}</h1>')
+    if session_id:
+        parts.append(f'<h2>Session ID: {html_escape(session_id)}</h2>')
+
+    if phases:
+        parts.append('<h3>Phases</h3>')
+        parts.append('<ul>')
+        for ph in phases:
+            ph_id = ph.get('id', '')
+            ph_name = ph.get('name', '')
+            parts.append(f'<li><strong>{html_escape(ph_id)} {html_escape(ph_name)}</strong>')
+            packets = ph.get('packets', [])
+            if packets:
+                parts.append('<ul>')
+                for pkt in packets:
+                    pid = pkt.get('packet_id', '')
+                    intent = pkt.get('intent', '')
+                    trace_link = pkt.get('trace_link', '')
+                    parts.append('<li>')
+                    parts.append(f'{html_escape(pid)}: {html_escape(intent)}')
+                    if trace_link:
+                        parts.append(f'<br><small>{html_escape(trace_link)}</small>')
+                    parts.append('</li>')
+                parts.append('</ul>')
+            parts.append('</li>')
+        parts.append('</ul>')
+
+    if tcp_trace:
+        parts.append('<h3>TCP Packet Trace</h3>')
+        parts.append('<ol>')
+        for entry in tcp_trace.get('trace', []):
+            phase_name = entry.get('phase', '')
+            parts.append(f'<li><strong>{html_escape(phase_name)}</strong>')
+            packet = entry.get('packet', {})
+            header = packet.get('header', {})
+            payload = packet.get('payload', {})
+            if header:
+                parts.append('<details><summary>Header</summary><pre>')
+                parts.append(html_escape(yaml.dump(header, allow_unicode=True)))
+                parts.append('</pre></details>')
+            if payload:
+                parts.append('<details><summary>Payload</summary><pre>')
+                parts.append(html_escape(yaml.dump(payload, allow_unicode=True)))
+                parts.append('</pre></details>')
+            parts.append('</li>')
+        parts.append('</ol>')
+
+    parts.append('</body>')
+    parts.append('</html>')
+    return '\n'.join(parts)
+
+
+def main():
+    input_path = Path('structured_yaml/validated_yaml/ai_tcp_dmc_trace.yaml')
+    output_dir = Path('generated_html')
+    output_dir.mkdir(exist_ok=True)
+    output_path = output_dir / 'DMC_20250618.html'
+
+    data = load_yaml(input_path)
+    meta, session, tcp_trace = extract_data(data)
+    title = meta.get('title', '')
+    session_id = session.get('session_id', '')
+    phases = session.get('phases', [])
+    html = create_html(title, session_id, phases, tcp_trace)
+    output_path.write_text(html, encoding='utf-8')
+    print(f'HTML generated at {output_path}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `gen_dmc_html.py` script to render the DMC trace YAML as HTML
- create output example `generated_html/DMC_20250618.html`

## Testing
- `tools/gen_dmc_html.py`


------
https://chatgpt.com/codex/tasks/task_e_68525126e8a48333bf43ec35f563882c