### PR TITLE
Add structured YAML Mermaid extraction

### DIFF
--- a/tools/gen_structure_html.py
+++ b/tools/gen_structure_html.py
@@ -1,34 +1,88 @@
 from pathlib import Path
+import yaml
 
-mmd_path = Path("docs/structure_map/master_schema.mmd")
-html_path = Path("generated_html/structure_map_master_schema.html")
+YAML_DIR = Path("structured_yaml")
+STRUCTURE_DIR = Path("docs/structure_map")
+OUTPUT_DIR = Path("generated_html")
 
-if not mmd_path.exists():
-    print(f"❌ Mermaid source not found: {mmd_path}")
-    exit(1)
 
-mmd_content = mmd_path.read_text(encoding="utf-8")
+def _find_mermaid_blocks(obj: object) -> list[str]:
+    """Recursively collect Mermaid code blocks under graph_payload.graph_structure."""
+    blocks: list[str] = []
 
-html_template = f"""<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>AI-TCP Structure Map</title>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs"></script>
-  <style>
-    body {{ background: #fffbe6; font-family: sans-serif; padding: 1em; }}
-    .mermaid {{ background: #fff; border: 1px solid #ccc; border-radius: 8px; padding: 1em; }}
-  </style>
-</head>
-<body>
-  <h2>Structure Map: master_schema_v1.yaml</h2>
-  <div class="mermaid">
-{mmd_content}
-  </div>
-</body>
-</html>
-"""
+    def _walk(node: object) -> None:
+        if isinstance(node, dict):
+            if "graph_payload" in node:
+                gp = node.get("graph_payload")
+                if isinstance(gp, dict):
+                    gs = gp.get("graph_structure")
+                    if isinstance(gs, str) and gs.strip().startswith("mmd:"):
+                        blocks.append(gs.split("mmd:", 1)[1].strip())
+            for v in node.values():
+                _walk(v)
+        elif isinstance(node, list):
+            for item in node:
+                _walk(item)
 
-html_path.parent.mkdir(parents=True, exist_ok=True)
-html_path.write_text(html_template, encoding="utf-8")
-print(f"✅ HTML structure map written to {html_path}")
+    _walk(obj)
+    return blocks
+
+
+def generate_html(yaml_path: Path) -> None:
+    structure_path = STRUCTURE_DIR / f"{yaml_path.stem}.mmd"
+    mmd_content = structure_path.read_text(encoding="utf-8") if structure_path.exists() else ""
+
+    try:
+        data = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as e:
+        print(f"❌ Failed to parse {yaml_path}: {e}")
+        return
+
+    mermaid_blocks = _find_mermaid_blocks(data)
+
+    html_lines = [
+        "<!DOCTYPE html>",
+        "<html lang=\"en\">",
+        "<head>",
+        "  <meta charset=\"UTF-8\">",
+        f"  <title>Structure Map: {yaml_path.name}</title>",
+        "  <script type=\"module\" src=\"https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs\"></script>",
+        "  <style>",
+        "    body { background: #fffbe6; font-family: sans-serif; padding: 1em; }",
+        "    .mermaid { background: #fff; border: 1px solid #ccc; border-radius: 8px; padding: 1em; }",
+        "  </style>",
+        "</head>",
+        "<body>",
+        f"  <h2>Structure Map: {yaml_path.name}</h2>",
+    ]
+
+    if mmd_content:
+        html_lines.append("  <div class=\"mermaid\">")
+        html_lines.append(mmd_content)
+        html_lines.append("  </div>")
+
+    if mermaid_blocks:
+        html_lines.append("  <h3>Mermaid構造:</h3>")
+        for block in mermaid_blocks:
+            html_lines.append("  <!-- Mermaid構造部 -->")
+            html_lines.append("  <pre><code class=\"language-mermaid\">")
+            html_lines.append(block)
+            html_lines.append("  </code></pre>")
+
+    html_lines.append("  <script>mermaid.initialize({startOnLoad:true});</script>")
+    html_lines.append("</body>")
+    html_lines.append("</html>")
+
+    output_path = OUTPUT_DIR / f"structure_map_{yaml_path.stem}.html"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(html_lines), encoding="utf-8")
+    print(f"✅ HTML structure map written to {output_path}")
+
+
+def main() -> None:
+    for yaml_file in sorted(YAML_DIR.glob("*.yaml")):
+        generate_html(yaml_file)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- show Mermaid graphs from `graph_payload.graph_structure` fields
- support multiple diagrams per YAML file
- generate HTML files for every YAML in `structured_yaml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python tools/gen_structure_html.py` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68579f7dfec88333ac4989713747bd4c