### PR TITLE
Add lint warnings to YAML validator

### DIFF
--- a/docs/structure_map/README.md
+++ b/docs/structure_map/README.md
@@ -38,7 +38,7 @@ This directory contains structured YAML definitions for the AI-TCP protocol and 
 python tools/validate_structured_yaml.py structured_yaml/<file>.yaml
 ```
 
-- 成功時：✅ Valid structured YAML.
+- 成功時：✅ Valid YAML.
 - 失敗時：❌ Missing required keys: ...
 
 ---

--- a/tools/validate_structured_yaml.py
+++ b/tools/validate_structured_yaml.py
@@ -11,57 +11,54 @@ def scan_warnings(path: str):
     with open(path, "r", encoding="utf-8") as f:
         lines = f.readlines()
 
-    inside_graph = False
-    graph_indent = 0
     for lineno, line in enumerate(lines, start=1):
         stripped = line.strip()
 
         # check for commented-out reference keys
-        if re.search(r"^\s*#\s*\$?ref:", line):
-            warnings.append((lineno, "参照風記述あり：手動整合性確認要"))
+        if stripped.startswith("#") and re.search(r"(\$ref:|#ref:)", stripped):
+            warnings.append((lineno, "$ref-like comment found"))
 
         # heuristic check for invalid in-line comment syntax
         if "#" in line and not stripped.startswith("#"):
             prefix = line.split("#", 1)[0]
             if not re.search(r"['\"]", prefix) and not re.search(r"[:\-\[\{,]\s*$", prefix.strip()):
-                warnings.append((lineno, "無効なコメント構文の可能性"))
+                warnings.append((lineno, "Possibly invalid YAML comment"))
 
-        # track graph_payload section
-        if re.match(r"^\s*graph_payload\s*:", line):
-            inside_graph = True
-            graph_indent = len(line) - len(line.lstrip())
-        elif inside_graph:
-            curr_indent = len(line) - len(line.lstrip())
-            if curr_indent <= graph_indent:
-                inside_graph = False
-            elif "mmd:" in line:
-                warnings.append((lineno, "Mermaidブロック候補あり"))
+        # detect value that starts with 'mmd:'
+        if re.search(r":\s*mmd:", line) or re.match(r"^\s*-\s*mmd:", stripped):
+            warnings.append((lineno, "Mermaid block candidate detected"))
 
     return warnings
 
 
 def validate_file(path: str) -> int:
     warnings = scan_warnings(path)
-    for lineno, msg in warnings:
-        print(f"Warning: {path}:{lineno}: {msg}")
 
     with open(path, "r", encoding="utf-8") as f:
         try:
             data = yaml.safe_load(f)
         except yaml.YAMLError as e:
             print(f"YAML syntax error: {e}")
+            for lineno, msg in warnings:
+                print(f"⚠ Warning: {path}:{lineno}: {msg}")
             return 1
 
     if not isinstance(data, dict):
         print("Top-level YAML is not a dictionary.")
+        for lineno, msg in warnings:
+            print(f"⚠ Warning: {path}:{lineno}: {msg}")
         return 1
 
     missing = [key for key in REQUIRED_KEYS if key not in data]
     if missing:
         print(f"Missing required keys: {', '.join(missing)}")
+        for lineno, msg in warnings:
+            print(f"⚠ Warning: {path}:{lineno}: {msg}")
         return 1
 
-    print("✅ Valid structured YAML.")
+    print("✅ Valid YAML.")
+    for lineno, msg in warnings:
+        print(f"⚠ Warning: {path}:{lineno}: {msg}")
     return 0
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- warn when `$ref` style comments, Mermaid blocks or stray comments appear
- update output ordering for `validate_structured_yaml.py`
- document new success message

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68579f8ca4d08333bf08d6647135eaff