### PR TITLE
Add YAML source links in generated HTML

### DIFF
--- a/generated_html/DMC_20250618.html
+++ b/generated_html/DMC_20250618.html
@@ -91,6 +91,7 @@
     </style>
 </head>
 <body>
+<p><a href="../structured_yaml/validated_yaml/ai_tcp_dmc_trace.yaml" target="_blank">🔗 YAMLソースを見る</a></p>
 
     <div class="container">
         <h1>DMCセッション再生: AI-TCP PoC</h1>

--- a/generated_html/dmc_html_index.html
+++ b/generated_html/dmc_html_index.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="../html_templates/structured_index_style.css">
 </head>
 <body>
+  <p><a href="../structured_yaml/validated_yaml/ai_tcp_dmc_trace.yaml" target="_blank">🔗 YAMLソースを見る</a></p>
   <h1>🧠 DMC Sessions (Mental Care)</h1>
   <p>This page lists all HTML-rendered Direct Mental Care sessions.</p>
   <ul>

--- a/generated_html/index_all_generated.html
+++ b/generated_html/index_all_generated.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="../html_templates/structured_index_style.css">
 </head>
 <body>
+  <p><a href="../structured_yaml/master_schema_v1.yaml" target="_blank">🔗 YAMLソースを見る</a></p>
   <h1>📡 AI-TCP: Generated Output Index</h1>
   <p>This is the unified landing page for exploring all auto-generated outputs in the AI-TCP project.</p>
 

--- a/generated_html/index_dmc_sessions.html
+++ b/generated_html/index_dmc_sessions.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="../html_templates/structured_index_style.css">
 </head>
 <body>
+  <p><a href="../structured_yaml/validated_yaml/ai_tcp_dmc_trace.yaml" target="_blank">🔗 YAMLソースを見る</a></p>
   <h1>🧠 DMC Sessions (Mental Care)</h1>
   <p>This page lists all HTML-rendered Direct Mental Care sessions.</p>
   <ul>

--- a/generated_html/structure_map_master_schema.html
+++ b/generated_html/structure_map_master_schema.html
@@ -11,6 +11,7 @@
 </head>
 <body>
   <h2>Structure Map: master_schema_v1.yaml</h2>
+  <p><a href="../structured_yaml/master_schema_v1.yaml" target="_blank">🔗 YAMLソースを見る</a></p>
   <div class="mermaid">
 graph TD
   root["structure"]

--- a/generated_html/structured_yaml_index.html
+++ b/generated_html/structured_yaml_index.html
@@ -13,6 +13,7 @@
   </style>
 </head>
 <body>
+  <p><a href="../structured_yaml/master_schema_v1.yaml" target="_blank">🔗 YAMLソースを見る</a></p>
   <h1>🧾 AI-TCP Structured YAML Session Index</h1>
   <p>This page lists PoC YAML sessions for AI-TCP protocols.</p>
 

--- a/scripts/gen_dmc_html.py
+++ b/scripts/gen_dmc_html.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+import os
 import re
 import sys
 import webbrowser
@@ -216,6 +217,8 @@ def main() -> None:
         raise FileExistsError(f"{output_path} already exists. Use --force to overwrite")
 
     body_html = generate_body_html(header, phases, tcp_trace, summary_html)
+    rel_link = os.path.relpath(input_path, output_path.parent)
+    body_html = f'<p><a href="{rel_link}" target="_blank">🔗 YAMLソースを見る</a></p>\n' + body_html
     final_html = apply_template(body_html, template_path, str(session_id))
 
     output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tools/gen_dmc_html.py
+++ b/tools/gen_dmc_html.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import os
 import yaml
 
 DMC_DIR = Path("dmc_sessions")
@@ -49,6 +50,8 @@ def generate_html_from_yaml(yaml_path: Path) -> None:
     yaml_text = yaml.dump(data, allow_unicode=True, sort_keys=False)
     mermaid = _extract_mermaid(_find_graph_structure(data))
 
+    rel_path = os.path.relpath(yaml_path, OUTPUT_DIR)
+
     html_parts = [
         "<!DOCTYPE html>",
         "<html lang=\"en\">",
@@ -63,7 +66,8 @@ def generate_html_from_yaml(yaml_path: Path) -> None:
         "    pre {white-space: pre-wrap;}",
         "  </style>",
         "</head>",
-        "<body>"
+        "<body>",
+        f"  <p><a href=\"{rel_path}\" target=\"_blank\">🔗 YAMLソースを見る</a></p>"
     ]
 
     html_parts.append("  <div class=\"yaml\">")

--- a/tools/gen_structure_html.py
+++ b/tools/gen_structure_html.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import os
 import yaml
 
 YAML_DIR = Path("structured_yaml")
@@ -40,6 +41,8 @@ def generate_html(yaml_path: Path) -> None:
 
     mermaid_blocks = _find_mermaid_blocks(data)
 
+    rel_path = os.path.relpath(yaml_path, OUTPUT_DIR)
+
     html_lines = [
         "<!DOCTYPE html>",
         "<html lang=\"en\">",
@@ -54,6 +57,7 @@ def generate_html(yaml_path: Path) -> None:
         "</head>",
         "<body>",
         f"  <h2>Structure Map: {yaml_path.name}</h2>",
+        f"  <p><a href=\"{rel_path}\" target=\"_blank\">🔗 YAMLソースを見る</a></p>",
     ]
 
     if mmd_content:


### PR DESCRIPTION
## Summary
- add relative YAML source link in generated HTML files
- update HTML generator scripts to insert YAML source links dynamically

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python validate_all.py` *(fails: master_schema_v1.yaml)*

------
https://chatgpt.com/codex/tasks/task_e_6857a17d24bc83338b1e8f3048cfedfa