### PR TITLE
Generate categorized YAML index

### DIFF
--- a/generated_html/structured_yaml_index.html
+++ b/generated_html/structured_yaml_index.html
@@ -3,31 +3,26 @@
 <head>
   <meta charset="UTF-8">
   <title>Structured YAML Index</title>
-  <style>
-    body { font-family: sans-serif; margin: 2rem; }
-    h1 { color: #333; }
-    h2 { color: #555; }
-    ul { line-height: 1.6; }
-    li { margin-bottom: 0.5em; }
-    .session-block { margin-bottom: 2em; padding: 1em; border: 1px solid #ddd; border-radius: 0.5em; }
-  </style>
 </head>
 <body>
-  <h1>🧾 AI-TCP Structured YAML Session Index</h1>
-  <p>This page lists PoC YAML sessions for AI-TCP protocols.</p>
-
-  
-    <div class="session-block">
-      <h2>master_schema_v1.yaml</h2>
-      <ul>
-        <li><b>Phase:</b> N/A</li>
-        <li><b>Agent:</b> N/A</li>
-        <li><b>Tags:</b> </li>
-        <li><b>Input:</b> N/A</li>
-        <li><b>Output:</b> N/A</li>
-      </ul>
-    </div>
-  
-
+  <h1>Structured YAML Index</h1>
+  <h2>Core Schemas</h2>
+  <ul>
+    <li><a href="../structured_yaml/master_schema_v1.yaml">master_schema_v1.yaml</a></li>
+  </ul>
+  <h2>Compliance Modules</h2>
+  <ul>
+    <li>No files found</li>
+  </ul>
+  <h2>Packet Structures</h2>
+  <ul>
+    <li>No files found</li>
+  </ul>
+  <h2>Other YAML Files</h2>
+  <ul>
+    <li><a href="../structured_yaml/validated_yaml/ai_tcp_dmc_trace.yaml">ai_tcp_dmc_trace.yaml</a></li>
+    <li><a href="../structured_yaml/validated_yaml/ai_tcp_poc_design.yaml">ai_tcp_poc_design.yaml</a></li>
+    <li><a href="../structured_yaml/validated_yaml/ai_tcp_timeline.yaml">ai_tcp_timeline.yaml</a></li>
+  </ul>
 </body>
 </html>

--- a/tools/gen_structured_yaml_simple_index.py
+++ b/tools/gen_structured_yaml_simple_index.py
@@ -1,0 +1,52 @@
+import os
+from pathlib import Path
+
+BASE_DIR = Path('structured_yaml')
+OUTPUT_FILE = Path('generated_html/structured_yaml_index.html')
+OUTPUT_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+categories = {
+    'Core Schemas': [],
+    'Compliance Modules': [],
+    'Packet Structures': [],
+    'Other YAML Files': [],
+}
+
+for path in BASE_DIR.rglob('*.yaml'):
+    name = path.name
+    lname = name.lower()
+    if 'compliance' in lname:
+        categories['Compliance Modules'].append(path)
+    elif 'packet' in lname or 'structure' in lname:
+        categories['Packet Structures'].append(path)
+    elif 'schema' in lname:
+        categories['Core Schemas'].append(path)
+    else:
+        categories['Other YAML Files'].append(path)
+
+html = [
+    '<!DOCTYPE html>',
+    '<html lang="en">',
+    '<head>',
+    '  <meta charset="UTF-8">',
+    '  <title>Structured YAML Index</title>',
+    '</head>',
+    '<body>',
+    '  <h1>Structured YAML Index</h1>',
+]
+
+for cat, files in categories.items():
+    html.append(f'  <h2>{cat}</h2>')
+    html.append('  <ul>')
+    if files:
+        for f in sorted(files):
+            rel = os.path.relpath(f, OUTPUT_FILE.parent)
+            html.append(f'    <li><a href="{rel}">{f.name}</a></li>')
+    else:
+        html.append('    <li>No files found</li>')
+    html.append('  </ul>')
+
+html.extend(['</body>', '</html>'])
+
+OUTPUT_FILE.write_text('\n'.join(html), encoding='utf-8')
+print(f'Generated {OUTPUT_FILE}')


### PR DESCRIPTION
## Summary
- implement `gen_structured_yaml_simple_index.py` to categorize YAML files into sections
- generate `structured_yaml_index.html` with section headings for Core Schemas, Compliance Modules, Packet Structures, and Other YAML Files

## Testing
- `python tools/gen_structured_yaml_simple_index.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6857a18b7fb48333adbf3256df4a3e12