### PR TITLE
Add portal generator script

### DIFF
--- a/generated_html/structure_index.html
+++ b/generated_html/structure_index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>AI-TCP Structure Index</title>
+  <link rel="stylesheet" href="../html_templates/structured_index_style.css">
+</head>
+<body>
+  <p><a href="../docs/AI-TCP_Structure/index.md" target="_blank">🔗 Markdownソースを見る</a></p>
+  <h1>AI-TCP Structure Index</h1>
+  <p>This portal links to key AI-TCP documents and tools.</p>
+  <p><i>Updated: 2025-06-22</i></p>
+  <h2>📚 RFC Drafts</h2>
+  <ul>
+    <li><a href="../docs/rfc_drafts/001_ai_tcp_overview.md" target="_blank">001 Overview</a></li>
+    <li><a href="../docs/rfc_drafts/002_llm_compliance.md" target="_blank">002 LLM Compliance</a></li>
+    <li><a href="../docs/rfc_drafts/003_packet_definition.md" target="_blank">003 Packet Structure</a></li>
+  </ul>
+  <h2>📦 Graph Payload</h2>
+  <ul>
+    <li><a href="../docs/graph_payload_usage.md" target="_blank">Graph Usage Guide</a></li>
+    <li><a href="../dmc_sessions/" target="_blank">Sample YAMLs (dmc_sessions)</a></li>
+    <li><a href="../generated_html/structure_map_master_schema.html" target="_blank">Mermaid HTML Map</a></li>
+  </ul>
+  <h2>🧪 PoC Tools & Docs</h2>
+  <ul>
+    <li><a href="../docs/poc_scenario.md" target="_blank">PoC Scenarios</a></li>
+    <li><a href="../generated_html/structured_yaml_index.html" target="_blank">Structured YAML Index</a></li>
+  </ul>
+</body>
+</html>

--- a/tools/gen_structure_index_html.py
+++ b/tools/gen_structure_index_html.py
@@ -1,0 +1,50 @@
+import re
+from datetime import date
+from pathlib import Path
+import os
+
+SOURCE = Path('docs/AI-TCP_Structure/index.md')
+OUTPUT = Path('generated_html/structure_index.html')
+OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+
+sections = []
+current = None
+for raw in SOURCE.read_text(encoding='utf-8').splitlines():
+    line = raw.strip()
+    if line.startswith('```'):
+        continue
+    if line.startswith('##'):
+        heading = line.lstrip('#').strip()
+        current = {'heading': heading, 'links': []}
+        sections.append(current)
+    elif line.startswith('-'):
+        m = re.search(r'\[([^\]]+)\]\(([^)]+)\)', line)
+        if m and current is not None:
+            text, href = m.groups()
+            current['links'].append((text, href))
+
+rel_src = os.path.relpath(SOURCE, OUTPUT.parent)
+html = [
+    '<!DOCTYPE html>',
+    '<html lang="en">',
+    '<head>',
+    '  <meta charset="UTF-8">',
+    '  <title>AI-TCP Structure Index</title>',
+    '  <link rel="stylesheet" href="../html_templates/structured_index_style.css">',
+    '</head>',
+    '<body>',
+    f'  <p><a href="{rel_src}" target="_blank">🔗 Markdownソースを見る</a></p>',
+    '  <h1>AI-TCP Structure Index</h1>',
+    '  <p>This portal links to key AI-TCP documents and tools.</p>',
+    f'  <p><i>Updated: {date.today().isoformat()}</i></p>',
+]
+for sec in sections:
+    html.append(f'  <h2>{sec["heading"]}</h2>')
+    html.append('  <ul>')
+    for text, href in sec['links']:
+        html.append(f'    <li><a href="{href}" target="_blank">{text}</a></li>')
+    html.append('  </ul>')
+html.extend(['</body>', '</html>'])
+
+OUTPUT.write_text('\n'.join(html), encoding='utf-8')
+print(f'Generated {OUTPUT}')


### PR DESCRIPTION
## Summary
- create `gen_structure_index_html.py` to convert Markdown index into structured HTML
- generate new `structure_index.html`

## Testing
- `python tools/gen_structure_index_html.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python validate_all.py` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6857a85b79b48333bf30d29b7c8f4bc2