### PR TITLE
Generate RFC draft index automatically

### DIFF
--- a/docs/rfc_drafts/README.md
+++ b/docs/rfc_drafts/README.md
@@ -1,29 +1,12 @@
-# 📑 AI-TCP RFC Draft Index
+# 📑 AI-TCP RFC Index
 
-This directory contains draft specifications for the AI-TCP protocol.
+Drafts
 
-## Available Drafts
+001_ai_tcp_overview.md
+AI-TCP is a lightweight, structured protocol for inter-AI communication using YAML, Graph Payloads (Mermaid), and traceable reasoning.
 
-- [001_ai_tcp_overview.md](001_ai_tcp_overview.md)  
-  *Purpose*: High-level design and use-case framing. Describes AI-TCP's intent, structure, and architecture.
+002_llm_compliance.md
+This document defines the compliance requirements for Large Language Models (LLMs) participating in AI-TCP communication. AI-TCP enables traceable, interpretable, and modular communication between autonomous AI agents. For such communication to succeed, participating LLMs must follow shared conventions in packet structure, field interpretation, and behavior.
 
-- [002_llm_compliance.md](002_llm_compliance.md)  
-  *Purpose*: Defines compliance requirements for LLMs. Includes trace logging rules and mandatory fields.
-
-- [003_packet_definition.md](003_packet_definition.md)  
-  *Purpose*: YAML schema for AI-TCP packets. Specifies minimal structure, lifecycle, and constraints.
-
-## Format & Conventions
-
-All documents use Markdown (`.md`) for readability and YAML for embedded examples.
-
-- Mermaid diagrams must use the `mmd:` prefix and be embedded in the `graph_payload.graph_structure` YAML field.
-- Code examples should use fenced code blocks (```yaml, ```mermaid) with language tags.
-- All RFC files are named as `RFC ###_topic.md` using 3-digit identifiers and snake_case.
-- Each RFC must begin with `# RFC ###: Title` and use numbered section headings (`## 1.`, `## 2.` etc).
-
-## Status
-
-All drafts listed here are currently in **PoC-phase**, and subject to iterative updates and refinement by AI and human reviewers.
-
-Future additions (e.g., `004_reasoning_diagnostics.md`, `005_security_considerations.md`) will follow the same structure and conventions.
+003_packet_definition.md
+This document formalizes the structure and minimal required fields for AI-TCP-compliant packets. These packets serve as the atomic units of communication between LLMs under the AI-TCP protocol.

--- a/generate_rfc_index.py
+++ b/generate_rfc_index.py
@@ -1,0 +1,55 @@
+import argparse
+import re
+from pathlib import Path
+
+RFC_DIR = Path('docs/rfc_drafts')
+README_PATH = RFC_DIR / 'README.md'
+
+
+def extract_info(path: Path, max_lines: int = 3) -> tuple[str, str, str]:
+    """Return (filename, title, summary) for the given RFC markdown file."""
+    lines = path.read_text(encoding='utf-8').splitlines()
+    title = ''
+    summary_lines: list[str] = []
+    heading_pattern = re.compile(r'^##\s+')
+    for i, line in enumerate(lines):
+        if line.startswith('# RFC'):
+            title = line.strip('# ').strip()
+        if re.match(r'^##\s+1\.', line):
+            j = i + 1
+            while j < len(lines) and lines[j].strip() == '':
+                j += 1
+            while j < len(lines) and len(summary_lines) < max_lines and not heading_pattern.match(lines[j]):
+                if lines[j].strip():
+                    summary_lines.append(lines[j].strip())
+                j += 1
+            break
+    summary = ' '.join(summary_lines)
+    return path.name, title, summary
+
+
+def build_readme(rfc_dir: Path) -> str:
+    rfc_files = sorted(rfc_dir.glob('[0-9][0-9][0-9]_*.md'), key=lambda p: p.name)
+    lines = ['# \U0001F4D1 AI-TCP RFC Index', '', 'Drafts', '']
+    for file in rfc_files:
+        _, _, summary = extract_info(file)
+        lines.append(file.name)
+        if summary:
+            lines.append(summary)
+        lines.append('')
+    return '\n'.join(lines).rstrip() + '\n'
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Generate RFC README index')
+    parser.add_argument('--dir', default=RFC_DIR, type=Path, help='RFC drafts directory')
+    parser.add_argument('--output', default=README_PATH, type=Path, help='Output README path')
+    args = parser.parse_args()
+
+    content = build_readme(args.dir)
+    args.output.write_text(content, encoding='utf-8')
+    print(f'Wrote {args.output}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- create `generate_rfc_index.py` to build an index from docs/rfc_drafts
- update `docs/rfc_drafts/README.md` using the new script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python generate_rfc_index.py`

------
https://chatgpt.com/codex/tasks/task_e_6857ba31c45483338ed4c3f40ceef15c