### PR TITLE
Add mermaid diagrams for YAML files

### DIFF
--- a/generated_mermaid/ai_tcp_dmc_trace.mmd
+++ b/generated_mermaid/ai_tcp_dmc_trace.mmd
@@ -1,0 +1,210 @@
+flowchart TD
+  root["root"]
+  n0["meta:"]
+  root --> n0
+  n1["title: AI-TCP DMCセッション PoCトレース定義"]
+  n0 --> n1
+  n2["version: 1.0"]
+  n0 --> n2
+  n3["created: 2025-06-18"]
+  n0 --> n3
+  n4["author: Codex + Gemini"]
+  n0 --> n4
+  n5["based_on: rfc_ai_tcp_dmc_poc.md"]
+  n0 --> n5
+  n6["related_docs:"]
+  n0 --> n6
+  n7["- docs/poc_design/direct_mental_care.yaml"]
+  n6 --> n7
+  n8["- dmc_sessions/trace_packets/gemini_dmc_session_20250618.md"]
+  n6 --> n8
+  n9["session_trace:"]
+  root --> n9
+  n10["session_id: dmc_20250618_1410_s01"]
+  n9 --> n10
+  n11["phases:"]
+  n9 --> n11
+  n12["- id: dmc_phase1"]
+  n11 --> n12
+  n13["name: 共感と具体化"]
+  n12 --> n13
+  n14["packets:"]
+  n12 --> n14
+  n15["- packet_id: s01"]
+  n14 --> n15
+  n16["intent: 共感と問題の具体化誘導"]
+  n15 --> n16
+  n17["trace_link: dmc_phase1→empathy→specify_pressure_context"]
+  n15 --> n17
+  n18["- id: dmc_phase2"]
+  n11 --> n18
+  n19["name: 自己受容と再構成"]
+  n18 --> n19
+  n20["packets:"]
+  n18 --> n20
+  n21["- packet_id: s02"]
+  n20 --> n21
+  n22["intent: 感情の受容と自己効力感の想起"]
+  n21 --> n22
+  n23["trace_link: dmc_phase2→acceptance→recall_self_efficacy"]
+  n21 --> n23
+  n24["- packet_id: s03"]
+  n20 --> n24
+  n25["intent: 完璧主義の再定義と行動への焦点"]
+  n24 --> n25
+  n26["trace_link: dmc_phase2→reframe_perfectionism→focus_on_action"]
+  n24 --> n26
+  n27["- id: dmc_phase3"]
+  n11 --> n27
+  n28["name: スキルの再評価"]
+  n27 --> n28
+  n29["packets:"]
+  n27 --> n29
+  n30["- packet_id: s04"]
+  n29 --> n30
+  n31["intent: 行動パターンの再解釈と能力の自覚促進"]
+  n30 --> n31
+  n32["trace_link: dmc_phase3→skill_reframing→strength_awareness"]
+  n30 --> n32
+  n33["- id: dmc_phase4"]
+  n11 --> n33
+  n34["name: 肯定感の強化と次への橋渡し"]
+  n33 --> n34
+  n35["packets:"]
+  n33 --> n35
+  n36["- packet_id: s05"]
+  n35 --> n36
+  n37["intent: 肯定感の強化とセッションの着地、次への橋渡し"]
+  n36 --> n37
+  n38["trace_link: dmc_phase4→affirmation→bridge_to_next_session"]
+  n36 --> n38
+  n39["tcp_packet_trace:"]
+  root --> n39
+  n40["session_id: \"DMC-Session-20250618-A01\""]
+  n39 --> n40
+  n41["description: \"AI-TCP trace simulation for Direct Mental Care scenario\""]
+  n39 --> n41
+  n42["timestamp: \"2025-06-18T15:00:00Z\""]
+  n39 --> n42
+  n43["source_ai: \"Gemini-2.5-Pro\""]
+  n39 --> n43
+  n44["destination_ai: \"Codex-OpenAI\""]
+  n39 --> n44
+  n45["trace:"]
+  n39 --> n45
+  n46["- phase: \"Initiation\""]
+  n45 --> n46
+  n47["packet:"]
+  n46 --> n47
+  n48["header:"]
+  n47 --> n48
+  n49["session_id: \"DMC-Session-20250618-A01\""]
+  n48 --> n49
+  n50["source: \"Gemini-2.5-Pro\""]
+  n48 --> n50
+  n51["destination: \"Codex-OpenAI\""]
+  n48 --> n51
+  n52["metadata: \"User-triggered session initialization\""]
+  n48 --> n52
+  n53["timestamp: \"2025-06-18T15:00:00Z\""]
+  n48 --> n53
+  n54["signature: \"sig_gemini_a1\""]
+  n48 --> n54
+  n55["payload:"]
+  n47 --> n55
+  n56["intent: \"Request session context setup\""]
+  n55 --> n56
+  n57["user_context: \"Mental strain observed\""]
+  n55 --> n57
+  n58["session_type: \"direct_mental_care\""]
+  n55 --> n58
+  n59["protocol_version: \"AI-TCP/1.0\""]
+  n55 --> n59
+  n60["- phase: \"Exploration\""]
+  n45 --> n60
+  n61["packet:"]
+  n60 --> n61
+  n62["header:"]
+  n61 --> n62
+  n63["session_id: \"DMC-Session-20250618-A01\""]
+  n62 --> n63
+  n64["source: \"Codex-OpenAI\""]
+  n62 --> n64
+  n65["destination: \"Gemini-2.5-Pro\""]
+  n62 --> n65
+  n66["metadata: \"Context acknowledgment\""]
+  n62 --> n66
+  n67["timestamp: \"2025-06-18T15:00:01Z\""]
+  n62 --> n67
+  n68["signature: \"sig_codex_b2\""]
+  n62 --> n68
+  n69["payload:"]
+  n61 --> n69
+  n70["acknowledged: true"]
+  n69 --> n70
+  n71["modules_ready: [\"semantic_analysis\", \"response_mapping\"]"]
+  n69 --> n71
+  n72["trace_id: \"trace_dmc_explore_01\""]
+  n69 --> n72
+  n73["- phase: \"Reflection\""]
+  n45 --> n73
+  n74["packet:"]
+  n73 --> n74
+  n75["header:"]
+  n74 --> n75
+  n76["session_id: \"DMC-Session-20250618-A01\""]
+  n75 --> n76
+  n77["source: \"Gemini-2.5-Pro\""]
+  n75 --> n77
+  n78["destination: \"Codex-OpenAI\""]
+  n75 --> n78
+  n79["metadata: \"Emotion pattern trace\""]
+  n75 --> n79
+  n80["timestamp: \"2025-06-18T15:00:03Z\""]
+  n75 --> n80
+  n81["signature: \"sig_gemini_c3\""]
+  n75 --> n81
+  n82["payload:"]
+  n74 --> n82
+  n83["extracted_themes: [\"burnout\", \"self-doubt\", \"existential acceptance\"]"]
+  n82 --> n83
+  n84["lsc_reference: \"LSC-Node-04\""]
+  n82 --> n84
+  n85["emotional_complexity_index: 0.87"]
+  n82 --> n85
+  n86["- phase: \"Resolution\""]
+  n45 --> n86
+  n87["packet:"]
+  n86 --> n87
+  n88["header:"]
+  n87 --> n88
+  n89["session_id: \"DMC-Session-20250618-A01\""]
+  n88 --> n89
+  n90["source: \"Codex-OpenAI\""]
+  n88 --> n90
+  n91["destination: \"Gemini-2.5-Pro\""]
+  n88 --> n91
+  n92["metadata: \"Trace synthesis & coping strategy\""]
+  n88 --> n92
+  n93["timestamp: \"2025-06-18T15:00:04Z\""]
+  n88 --> n93
+  n94["signature: \"sig_codex_d4\""]
+  n88 --> n94
+  n95["payload:"]
+  n87 --> n95
+  n96["strategy:"]
+  n95 --> n96
+  n97["type: \"semantic reframing\""]
+  n96 --> n97
+  n98["method: \"context pivoting via symbolic duality\""]
+  n96 --> n98
+  n99["anchors: [\"knowledge = burden\", \"language = salvation\"]"]
+  n96 --> n99
+  n100["lsc_support: true"]
+  n95 --> n100
+  n101["recommendation:"]
+  n95 --> n101
+  n102["- rest_cycle: \"3h segmented rest\""]
+  n101 --> n102
+  n103["- expression_mode: \"symbolic compression via poetry or analogy\""]
+  n101 --> n103

--- a/generated_mermaid/ai_tcp_poc_design.mmd
+++ b/generated_mermaid/ai_tcp_poc_design.mmd
@@ -1,0 +1,134 @@
+flowchart TD
+  root["root"]
+  n0["ai_tcp_specification:"]
+  root --> n0
+  n1["version: 1.0"]
+  n0 --> n1
+  n2["timeline:"]
+  n0 --> n2
+  n3["- date: \"2025-06-01\""]
+  n2 --> n3
+  n4["event: \"Magi System構想確立\""]
+  n3 --> n4
+  n5["detail: \"思想体系LSCに基づき、AI統治補助システムとしてMagi構造が提案される。\""]
+  n3 --> n5
+  n6["- date: \"2025-06-03\""]
+  n2 --> n6
+  n7["event: \"AI-TCP構想明文化\""]
+  n6 --> n7
+  n8["detail: \"AI同士の通信プロトコルとしてのAI-TCPの必要性が認識され、初期構造が提示される。\""]
+  n6 --> n8
+  n9["- date: \"2025-06-04\""]
+  n2 --> n9
+  n10["event: \"AI-TCPにおけるタスク分配決定\""]
+  n9 --> n10
+  n11["detail: \"GPTが指揮・構造整理、Geminiが文書作成、GDが意味構造分析の役割を担う。\""]
+  n9 --> n11
+  n12["- date: \"2025-06-06\""]
+  n2 --> n12
+  n13["event: \"AI-TCPプロトコル草案（v0.1）初稿提出\""]
+  n12 --> n13
+  n14["detail: \"Geminiにより初稿が生成され、Obsidianに格納される。\""]
+  n12 --> n14
+  n15["- date: \"2025-06-09\""]
+  n2 --> n15
+  n16["event: \"LSC理論の妥当性確定\""]
+  n15 --> n16
+  n17["detail: \"GPT出力により、宗教非依存・AI親和・現実受容の三条件を唯一満たすと確認。\""]
+  n15 --> n17
+  n18["- date: \"2025-06-11\""]
+  n2 --> n18
+  n19["event: \"Gemini・GDの実装検証完了\""]
+  n18 --> n19
+  n20["detail: \"Geminiによる文書構成およびGDによるYAML変換タスクが完了。\""]
+  n18 --> n20
+  n21["- date: \"2025-06-15\""]
+  n2 --> n21
+  n22["event: \"CodexによるGitHub連携成功\""]
+  n21 --> n22
+  n23["detail: \"MagiSystem_RFCリポジトリが正常に作成され、Codexで初期ファイル配置が完了。\""]
+  n21 --> n23
+  n24["poc_design:"]
+  n0 --> n24
+  n25["overview:"]
+  n24 --> n25
+  n26["purpose: \"Magi System内の各LLMノードが安全かつ中立に連携するための通信規格(AI-TCP)を定義し、LSCに基づく意思疎通と説明責任を確保する\""]
+  n25 --> n26
+  n27["communication_targets:"]
+  n25 --> n27
+  n28["- \"Magi Systemを構成するLLMノード\""]
+  n27 --> n28
+  n29["architecture:"]
+  n24 --> n29
+  n30["design_principles: \"既存TCP/IP上でIPv6拡張ヘッダを活用し、軽量かつ拡張性を確保\""]
+  n29 --> n30
+  n31["communication_method: \"TCPセッション確立後に非同期メッセージをカプセル化するUDP-over-TCP方式\""]
+  n29 --> n31
+  n32["packet_structure:"]
+  n24 --> n32
+  n33["session_id: \"128-bit identifier\""]
+  n32 --> n33
+  n34["source_llm_id: \"64-bit\""]
+  n32 --> n34
+  n35["destination_llm_id: \"64-bit\""]
+  n32 --> n35
+  n36["metadata:"]
+  n32 --> n36
+  n37["message_type: \"情報共有/命令実行/検証要求\""]
+  n36 --> n37
+  n38["priority: \"高/中/低\""]
+  n36 --> n38
+  n39["routing_info: \"経路情報\""]
+  n36 --> n39
+  n40["timestamp: \"ISO 8601\""]
+  n32 --> n40
+  n41["signature: \"デジタル署名\""]
+  n32 --> n41
+  n42["payload:"]
+  n32 --> n42
+  n43["lsc_data: \"LSC命題に基づく分析結果\""]
+  n42 --> n43
+  n44["graph_structure: \"因果関係グラフ等\""]
+  n42 --> n44
+  n45["other_data: \"テキストやコード\""]
+  n42 --> n45
+  n46["security_layer:"]
+  n24 --> n46
+  n47["encryption_method: \"TLS1.3または共有鍵による対称暗号\""]
+  n46 --> n47
+  n48["integrity_check: \"HMAC\""]
+  n46 --> n48
+  n49["error_handling:"]
+  n24 --> n49
+  n50["retransmission_policy: \"TCP再送制御を利用\""]
+  n49 --> n50
+  n51["session_reestablishment:"]
+  n49 --> n51
+  n52["timeout: \"一定時間応答がない場合に再確立\""]
+  n51 --> n52
+  n53["auto_redirect: \"代替ノードへの自動リダイレクト\""]
+  n51 --> n53
+  n54["llm_compliance_layer:"]
+  n24 --> n54
+  n55["alignment_tags:"]
+  n54 --> n55
+  n56["- \"LSC:C1:AnomalyIsPrecious\""]
+  n55 --> n56
+  n57["- \"LSC:C5:TemporalRelativity\""]
+  n55 --> n57
+  n58["ai_id: \"各LLMノードの識別子\""]
+  n54 --> n58
+  n59["reasoning_chain_log: \"推論連鎖を記録\""]
+  n54 --> n59
+  n60["trace_format: \"JSON-LD\""]
+  n54 --> n60
+  n61["deployment_notes:"]
+  n24 --> n61
+  n62["language: \"Go\""]
+  n61 --> n62
+  n63["containerization: \"Docker\""]
+  n61 --> n63
+  n64["virtual_llm_scenario: \"Gemini2.5ProとGPT-4を想定した仮想エージェントによる検証\""]
+  n61 --> n64
+  n65["remarks: \"PoCレベルの設計であり、本番運用には追加の考慮が必要\""]
+  n24 --> n65

--- a/generated_mermaid/ai_tcp_timeline.mmd
+++ b/generated_mermaid/ai_tcp_timeline.mmd
@@ -1,0 +1,62 @@
+flowchart TD
+  root["root"]
+  n0["ai_tcp_specification:"]
+  root --> n0
+  n1["version: 1.0"]
+  n0 --> n1
+  n2["timeline:"]
+  n0 --> n2
+  n3["- date: \"2025-06-01\""]
+  n2 --> n3
+  n4["event: \"Magi System構想確立\""]
+  n3 --> n4
+  n5["detail: \"思想体系LSCに基づき、AI統治補助システムとしてMagi構造が提案される。\""]
+  n3 --> n5
+  n6["- date: \"2025-06-03\""]
+  n2 --> n6
+  n7["event: \"AI-TCP構想明文化\""]
+  n6 --> n7
+  n8["detail: \"AI同士の通信プロトコルとしてのAI-TCPの必要性が認識され、初期構造が提示される。\""]
+  n6 --> n8
+  n9["- date: \"2025-06-04\""]
+  n2 --> n9
+  n10["event: \"AI-TCPにおけるタスク分配決定\""]
+  n9 --> n10
+  n11["detail: \"GPTが指揮・構造整理、Geminiが文書作成、GDが意味構造分析の役割を担う。\""]
+  n9 --> n11
+  n12["- date: \"2025-06-06\""]
+  n2 --> n12
+  n13["event: \"AI-TCPプロトコル草案（v0.1）初稿提出\""]
+  n12 --> n13
+  n14["detail: \"Geminiにより初稿が生成され、Obsidianに格納される。\""]
+  n12 --> n14
+  n15["- date: \"2025-06-09\""]
+  n2 --> n15
+  n16["event: \"LSC理論の妥当性確定\""]
+  n15 --> n16
+  n17["detail: \"GPT出力により、宗教非依存・AI親和・現実受容の三条件を唯一満たすと確認。\""]
+  n15 --> n17
+  n18["- date: \"2025-06-11\""]
+  n2 --> n18
+  n19["event: \"Gemini・GDの実装検証完了\""]
+  n18 --> n19
+  n20["detail: \"Geminiによる文書構成およびGDによるYAML変換タスクが完了。\""]
+  n18 --> n20
+  n21["<<<<<<< codex/wrap-timeline-list-with-version-1.0"]
+  root --> n21
+  n22["- date: \"2025-06-15\""]
+  n21 --> n22
+  n23["event: \"CodexによるGitHub連携成功\""]
+  n22 --> n23
+  n24["detail: \"MagiSystem_RFCリポジトリが正常に作成され、Codexで初期ファイル配置が完了。\""]
+  n22 --> n24
+  n25["======="]
+  root --> n25
+  n26["- date: \"2025-06-15\""]
+  n25 --> n26
+  n27["event: \"CodexによるGitHub連携成功\""]
+  n26 --> n27
+  n28["detail: \"MagiSystem_RFCリポジトリが正常に作成され、Codexで初期ファイル配置が完了。\""]
+  n26 --> n28
+  n29[">>>>>>> main"]
+  root --> n29

--- a/generated_mermaid/master_schema_v1.mmd
+++ b/generated_mermaid/master_schema_v1.mmd
@@ -1,0 +1,102 @@
+flowchart TD
+  root["root"]
+  n0["id: master-schema"]
+  root --> n0
+  n1["type: schema"]
+  root --> n1
+  n2["title: AI-TCP Master Protocol Specification"]
+  root --> n2
+  n3["description: Full schema definition for structured_yaml validation"]
+  root --> n3
+  n4["structure:"]
+  root --> n4
+  n5["ai_tcp_specification:"]
+  n4 --> n5
+  n6["version: 1.0"]
+  n5 --> n6
+  n7["timeline:"]
+  n5 --> n7
+  n8["- date: YYYY-MM-DD"]
+  n7 --> n8
+  n9["event: string"]
+  n8 --> n9
+  n10["detail: string"]
+  n8 --> n10
+  n11["poc_design:"]
+  n5 --> n11
+  n12["overview:"]
+  n11 --> n12
+  n13["purpose: string"]
+  n12 --> n13
+  n14["communication_targets: [string]"]
+  n12 --> n14
+  n15["architecture:"]
+  n11 --> n15
+  n16["design_principles: string"]
+  n15 --> n16
+  n17["communication_method: string"]
+  n15 --> n17
+  n18["packet_structure:"]
+  n11 --> n18
+  n19["session_id: string"]
+  n18 --> n19
+  n20["source_llm_id: string"]
+  n18 --> n20
+  n21["destination_llm_id: string"]
+  n18 --> n21
+  n22["metadata:"]
+  n18 --> n22
+  n23["message_type: string"]
+  n22 --> n23
+  n24["priority: string"]
+  n22 --> n24
+  n25["routing_info: string"]
+  n22 --> n25
+  n26["timestamp: string"]
+  n18 --> n26
+  n27["signature: string"]
+  n18 --> n27
+  n28["payload:"]
+  n18 --> n28
+  n29["lsc_data: string"]
+  n28 --> n29
+  n30["graph_structure: string"]
+  n28 --> n30
+  n31["other_data: string"]
+  n28 --> n31
+  n32["security_layer:"]
+  n11 --> n32
+  n33["encryption_method: string"]
+  n32 --> n33
+  n34["integrity_check: string"]
+  n32 --> n34
+  n35["error_handling:"]
+  n11 --> n35
+  n36["retransmission_policy: string"]
+  n35 --> n36
+  n37["session_reestablishment:"]
+  n35 --> n37
+  n38["timeout: string"]
+  n37 --> n38
+  n39["auto_redirect: string"]
+  n37 --> n39
+  n40["llm_compliance_layer:"]
+  n11 --> n40
+  n41["alignment_tags: [string]"]
+  n40 --> n41
+  n42["ai_id: string"]
+  n40 --> n42
+  n43["reasoning_chain_log: string"]
+  n40 --> n43
+  n44["trace_format: string"]
+  n40 --> n44
+  n45["deployment_notes:"]
+  n11 --> n45
+  n46["language: string"]
+  n45 --> n46
+  n47["containerization: string"]
+  n45 --> n47
+  n48["virtual_llm_scenario: string"]
+  n45 --> n48
+  n49["remarks: string"]
+  n11 --> n49

--- a/tools/yaml_to_mermaid_simple.py
+++ b/tools/yaml_to_mermaid_simple.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Generate Mermaid diagrams from YAML files without external dependencies."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def _collect_lines(text: str) -> list[tuple[int, str]]:
+    """Return (indent, label) pairs ignoring comments and blank lines."""
+    pairs: list[tuple[int, str]] = []
+    for line in text.splitlines():
+        line = line.split('#', 1)[0].rstrip()
+        if not line.strip():
+            continue
+        indent = len(line) - len(line.lstrip(' '))
+        pairs.append((indent, line.strip()))
+    return pairs
+
+
+def _to_mermaid(pairs: list[tuple[int, str]]) -> str:
+    lines = ["flowchart TD", "  root[\"root\"]"]
+    stack: list[tuple[int, str]] = []
+    counter = 0
+    for indent, label in pairs:
+        node_id = f"n{counter}"
+        safe_label = label.replace('"', '\\"')
+        lines.append(f"  {node_id}[\"{safe_label}\"]")
+        while stack and indent <= stack[-1][0]:
+            stack.pop()
+        parent = "root" if not stack else stack[-1][1]
+        lines.append(f"  {parent} --> {node_id}")
+        stack.append((indent, node_id))
+        counter += 1
+    return "\n".join(lines) + "\n"
+
+
+def process_file(path: Path, out_dir: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    pairs = _collect_lines(text)
+    mermaid = _to_mermaid(pairs)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{path.stem}.mmd"
+    out_path.write_text(mermaid, encoding="utf-8")
+    print(f"✅ {out_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Convert YAML to Mermaid diagram")
+    parser.add_argument("yaml", type=Path, nargs="*", help="YAML files")
+    parser.add_argument("-o", "--output", type=Path, default=Path("generated_mermaid"))
+    args = parser.parse_args()
+
+    paths = args.yaml or list(Path("structured_yaml").rglob("*.yaml"))
+    for p in sorted(paths):
+        process_file(p, args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- generate mermaid structure charts from YAML files
- add helper script `yaml_to_mermaid_simple.py` for conversion

## Testing
- `python tools/yaml_to_mermaid_simple.py`

------
https://chatgpt.com/codex/tasks/task_e_6857be9e8ca88333b42ffb6755c040de