### PR TITLE
Implement RFC README auto generator

### DIFF
--- a/docs/rfc_drafts/README.md
+++ b/docs/rfc_drafts/README.md
@@ -1,47 +1,8 @@
-# 📘 AI-TCP RFC Collection
+# 📑 AI-TCP RFC Drafts
 
-## 概要
-このディレクトリは、AI間通信プロトコル「AI-TCP」の仕様群（RFC）を収録しています。  
-各文書は独立して参照可能でありながら、全体構造の中で明確な役割を持ちます。
-
-## ドキュメント構成
-
-### RFC001: AI-TCP Overview
-- AI-TCPの設計哲学、背景、全体像を記述
-- Mermaidによる構造図を含む
-- [📄 RFC001を読む](./001_ai_tcp_overview.md)
-
-### RFC002: LLM Compliance Schema
-- LLMが準拠すべき入出力構造・役割記述・応答要件を定義
-- [📄 RFC002を読む](./002_llm_compliance.md)
-
-### RFC003: AI-TCP Packet Protocol
-- 通信単位としてのパケット構造、ヘッダ、ペイロード定義
-- Mermaid視覚構造付き
-- [📄 RFC003を読む](./003_packet_definition.md)
-
-### GG01: LLM Role Definitions
-- 各AIエージェントに割り当てる「役割階層」の定義
-- [📄 GG01を読む](./GG01_llm_roles.md)
-
-### GG02: Trace Annotation Syntax
-- トレース記法および思考ログの共通記述ルール
-- [📄 GG02を読む](./GG02_trace_annotation.md)
-
-### GG03: Fault Handling & Resilience
-- 例外処理、回復戦略、再実行指針などの統一ルール
-- [📄 GG03を読む](./GG03_fault_handling.md)
-
-### GG04: Security Policies
-- AI-TCPの安全基準、通信暗号化、アクセス制御ポリシー
-- [📄 GG04を読む](./GG04_security_policy.md)
-
-### GG05: Evaluation Metrics & Criteria
-- PoC評価、判定基準、スコア設計の標準化
-- [📄 GG05を読む](./GG05_evaluation_metrics.md)
-
-## インデックス
-- [📂 RFC一覧（rfc_index.md）](./rfc_index.md)
-
----
-*自動生成：G6タスク（GPT/Codex協調）*
+| Title | Created | Summary |
+| ----- | ------- | ------- |
+| [RFC 001: AI-TCP Protocol Overview](001_ai_tcp_overview.md) | 2025-06-22 | AI-TCP is a lightweight, structured protocol for inter-AI communication using YAML, Graph Payloads (Mermaid), and traceable reasoning. |
+| [RFC 002: LLM Compliance Layer in AI-TCP](002_llm_compliance.md) | 2025-06-22 | This document defines the compliance requirements for Large Language Models (LLMs) participating in AI-TCP communication. |
+| [RFC 003: AI-TCP Packet Structure Definition](003_packet_definition.md) | 2025-06-22 | This document formalizes the structure and minimal required fields for AI-TCP-compliant packets. These packets serve as the atomic units of communication between LLMs under the AI-TCP protocol. |
+| [RFC 004: Reasoning Trace & Thought Chain Structure](004_reasoning_trace_structure.md) | 2025-06-22 | This document defines the internal structure and semantics of `reasoning_trace` used in AI-TCP packets, enabling traceability and chain-of-thought modeling among LLMs. |

--- a/generate_rfc_readme.py
+++ b/generate_rfc_readme.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+import argparse
+import subprocess
+from pathlib import Path
+import re
+
+RFC_DIR = Path('docs/rfc_drafts')
+README_PATH = RFC_DIR / 'README.md'
+
+
+def git_creation_date(path: Path) -> str:
+    try:
+        result = subprocess.run(
+            ['git', 'log', '--format=%ad', '--date=short', '--follow', '--reverse', '--', str(path)],
+            stdout=subprocess.PIPE,
+            text=True,
+            check=True,
+        )
+        first_line = result.stdout.splitlines()[0]
+        return first_line.strip()
+    except Exception:
+        return 'Unknown'
+
+
+def extract_info(path: Path) -> tuple[str, str]:
+    text = path.read_text(encoding='utf-8')
+    lines = text.splitlines()
+    title = ''
+    summary_lines: list[str] = []
+    found_title = False
+    for i, line in enumerate(lines):
+        if not found_title and line.startswith('#'):
+            title = line.lstrip('#').strip()
+            found_title = True
+            continue
+        if found_title:
+            if line.strip() == '' or line.startswith('#'):
+                if summary_lines:
+                    break
+                else:
+                    continue
+            summary_lines.append(line.strip())
+    summary = ' '.join(summary_lines).strip()
+    return title, summary
+
+
+def build_readme(rfc_dir: Path) -> str:
+    files = sorted(p for p in rfc_dir.glob('*.md') if p.name != 'README.md')
+    header = ['# \U0001F4D1 AI-TCP RFC Drafts', '', '| Title | Created | Summary |', '| ----- | ------- | ------- |']
+    rows = []
+    for f in files:
+        title, summary = extract_info(f)
+        date = git_creation_date(f)
+        link = f'[{title}]({f.name})'
+        rows.append(f'| {link} | {date} | {summary} |')
+    return '\n'.join(header + rows) + '\n'
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Generate RFC README listing')
+    parser.add_argument('--dir', default=RFC_DIR, type=Path, help='RFC drafts directory')
+    parser.add_argument('--output', default=README_PATH, type=Path, help='Output README path')
+    args = parser.parse_args()
+
+    content = build_readme(args.dir)
+    args.output.write_text(content, encoding='utf-8')
+    print(f'Wrote {args.output}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `generate_rfc_readme.py` script
- use it to generate `docs/rfc_drafts/README.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python validate_all.py` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6857bebbf94c8333913ff3b349c6d89d