### PR TITLE
Generate RFC table of contents

### DIFF
--- a/docs/rfc_drafts/README.md
+++ b/docs/rfc_drafts/README.md
@@ -1,8 +1,6 @@
-# 📑 AI-TCP RFC Drafts
+# AI-TCP RFC Drafts
 
-| Title | Created | Summary |
-| ----- | ------- | ------- |
-| [RFC 001: AI-TCP Protocol Overview](001_ai_tcp_overview.md) | 2025-06-22 | AI-TCP is a lightweight, structured protocol for inter-AI communication using YAML, Graph Payloads (Mermaid), and traceable reasoning. |
-| [RFC 002: LLM Compliance Layer in AI-TCP](002_llm_compliance.md) | 2025-06-22 | This document defines the compliance requirements for Large Language Models (LLMs) participating in AI-TCP communication. |
-| [RFC 003: AI-TCP Packet Structure Definition](003_packet_definition.md) | 2025-06-22 | This document formalizes the structure and minimal required fields for AI-TCP-compliant packets. These packets serve as the atomic units of communication between LLMs under the AI-TCP protocol. |
-| [RFC 004: Reasoning Trace & Thought Chain Structure](004_reasoning_trace_structure.md) | 2025-06-22 | This document defines the internal structure and semantics of `reasoning_trace` used in AI-TCP packets, enabling traceability and chain-of-thought modeling among LLMs. |
+- [001_ai_tcp_overview.md](001_ai_tcp_overview.md) - RFC 001: AI-TCP Protocol Overview (Updated: 2025-06-22)
+- [002_llm_compliance.md](002_llm_compliance.md) - RFC 002: LLM Compliance Layer in AI-TCP (Updated: 2025-06-22)
+- [003_packet_definition.md](003_packet_definition.md) - RFC 003: AI-TCP Packet Structure Definition (Updated: 2025-06-22)
+- [004_reasoning_trace_structure.md](004_reasoning_trace_structure.md) - RFC 004: Reasoning Trace & Thought Chain Structure (Updated: 2025-06-22)

--- a/generate_rfc_toc.py
+++ b/generate_rfc_toc.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+import argparse
+import subprocess
+from pathlib import Path
+import re
+
+RFC_DIR = Path('docs/rfc_drafts')
+README_PATH = RFC_DIR / 'README.md'
+
+
+def git_last_modified_date(path: Path) -> str:
+    try:
+        result = subprocess.run(
+            ['git', 'log', '-1', '--format=%ad', '--date=short', '--', str(path)],
+            stdout=subprocess.PIPE,
+            text=True,
+            check=True,
+        )
+        return result.stdout.splitlines()[0].strip()
+    except Exception:
+        return 'Unknown'
+
+
+def extract_title(path: Path) -> str:
+    for line in path.read_text(encoding='utf-8').splitlines():
+        if line.startswith('# '):
+            return line.lstrip('#').strip()
+    return ''
+
+
+def build_readme(rfc_dir: Path) -> str:
+    files = sorted([p for p in rfc_dir.glob('*.md') if p.name != 'README.md'])
+    lines = ['# AI-TCP RFC Drafts', '']
+    for f in files:
+        title = extract_title(f)
+        date = git_last_modified_date(f)
+        lines.append(f"- [{f.name}]({f.name}) - {title} (Updated: {date})")
+    lines.append('')
+    return '\n'.join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Generate RFC README TOC')
+    parser.add_argument('--dir', default=RFC_DIR, type=Path, help='RFC drafts directory')
+    parser.add_argument('--output', default=README_PATH, type=Path, help='Output README path')
+    args = parser.parse_args()
+
+    content = build_readme(args.dir)
+    args.output.write_text(content, encoding='utf-8')
+    print(f'Wrote {args.output}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- create `generate_rfc_toc.py` to build a simple TOC
- regenerate `docs/rfc_drafts/README.md` using the new script

## Testing
- `python3 generate_rfc_toc.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6857c0f058508333aa9c896685dca138