### PR TITLE
Extract Mermaid code from RFC drafts

### DIFF
--- a/docs/mermaid/001_ai_tcp_overview.mmd.md
+++ b/docs/mermaid/001_ai_tcp_overview.mmd.md
@@ -1,0 +1,15 @@
+```mermaid
+flowchart TD
+A[Start] --> B[Parse YAML]
+B --> C{Validate}
+C --> D[Reasoning]
+D --> E[Reply]
+```
+
+```mermaid
+flowchart TD
+A[User Request] --> B[Parse Request]
+B --> C{Intent Detected?}
+C -- Yes --> D[Route Internally]
+C -- No --> E[Ask Clarification]
+```

--- a/docs/mermaid/003_packet_definition.mmd.md
+++ b/docs/mermaid/003_packet_definition.mmd.md
@@ -1,0 +1,4 @@
+```mermaid
+flowchart TD
+A --> B
+```

--- a/docs/rfc_drafts/001_ai_tcp_overview.md
+++ b/docs/rfc_drafts/001_ai_tcp_overview.md
@@ -28,11 +28,7 @@ Each packet includes reasoning logs, profile metadata, and an embedded graph str
 ```yaml
 graph_payload:
   graph_structure: |
-    mmd:flowchart TD
-    A[Start] --> B[Parse YAML]
-    B --> C{Validate}
-    C --> D[Reasoning]
-    D --> E[Reply]
+    [Mermaid構造は mermaid/001_ai_tcp_overview.mmd.md に移動されました]
 reasoning_trace:
   - step: 1
     input: Receive
@@ -67,11 +63,7 @@ The `graph_payload.graph_structure` field is expected to contain a Mermaid-forma
 ```yaml
 graph_payload:
   graph_structure: |
-    mmd:flowchart TD
-    A[User Request] --> B[Parse Request]
-    B --> C{Intent Detected?}
-    C -- Yes --> D[Route Internally]
-    C -- No --> E[Ask Clarification]
+    [Mermaid構造は mermaid/001_ai_tcp_overview.mmd.md に移動されました]
 reasoning_trace:
   - step: 1
     input: "Request: Book a flight"

--- a/docs/rfc_drafts/003_packet_definition.md
+++ b/docs/rfc_drafts/003_packet_definition.md
@@ -26,8 +26,7 @@ To formalize the structure and minimal required fields for any AI-TCP-compliant 
 ```yaml
 graph_payload:
   graph_structure: |
-    mmd:flowchart TD
-    A --> B
+    [Mermaid構造は mermaid/003_packet_definition.mmd.md に移動されました]
 
 reasoning_trace:
   - step: 1


### PR DESCRIPTION
## Summary
- extract Mermaid sections from RFC drafts
- store extracted diagrams under `docs/mermaid`
- replace moved sections in docs with relocation note

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6857c0f8820c833388bfa5fed41a7be6