### PR TITLE
Add refined RFC drafts

### DIFF
--- a/docs/rfc_drafts/refined/001_ai_tcp_overview.md
+++ b/docs/rfc_drafts/refined/001_ai_tcp_overview.md
@@ -1,0 +1,103 @@
+# RFC 001: AI-TCP Protocol Overview
+
+## 1. Purpose
+AI-TCP is a lightweight, structured protocol for inter-AI communication using YAML, Graph Payloads (Mermaid), and traceable reasoning.
+
+## 2. Terminology
+- **LLM**: Large Language Model
+- **Packet**: A YAML-encoded unit containing trace, graph_payload, metadata
+- **Compliance Layer**: Structural expectations for interpreting packets
+
+## 3. Architecture
+- YAML-based packet structure
+- Trace log → Reasoning transfer
+- Graph structure → Mental model embedding
+
+## 4. Packet Lifecycle
+1. Construct YAML with `graph_payload`, `reasoning_trace`
+2. Send to receiving LLM
+3. Receiving LLM parses structure
+4. Optionally replies with `auto_redirect` and updated context
+
+### YAML Integration
+
+AI-TCP packets are encoded as standard YAML documents. The structure follows the specification defined in [RFC 003](003_packet_definition.md).
+
+Each packet includes reasoning logs, profile metadata, and an embedded graph structure representing mental models.
+
+```yaml
+graph_payload:
+  graph_structure: |
+    mmd:flowchart TD
+    A[Start] --> B[Parse YAML]
+    B --> C{Validate}
+    C --> D[Reasoning]
+    D --> E[Reply]
+reasoning_trace:
+  - step: 1
+    input: Receive
+    output: Parse and Validate
+llm_profile:
+  id: GPT-4
+  version: 2025.3
+```
+
+The `graph_structure` field begins with the `mmd:` prefix to indicate Mermaid encoding. The receiving LLM interprets this structure in conjunction with the reasoning trace to determine its next action.
+
+## 5. Security & Scope
+AI-TCP is intended for inter-AI communication, not for user-facing authentication or cryptographic security.
+
+## 6. Reference
+- YAML Core 1.2
+- Mermaid JS 10+
+- AI-TCP PoC 2025
+
+## 7. Graph Semantics
+The `graph_payload.graph_structure` field is expected to contain a Mermaid-formatted graph, prefixed by `mmd:`.
+
+- **Nodes** represent conceptual or reasoning units (e.g., Parse, Validate, Evaluate).
+- **Edges** represent logical or causal transitions between those units.
+- **Branching** may represent reasoning forks or conditional paths.
+- The graph provides an interpretable mental model that complements the reasoning_trace log.
+
+## 8. Example Interaction
+
+### Sending Packet Example
+
+```yaml
+graph_payload:
+  graph_structure: |
+    mmd:flowchart TD
+    A[User Request] --> B[Parse Request]
+    B --> C{Intent Detected?}
+    C -- Yes --> D[Route Internally]
+    C -- No --> E[Ask Clarification]
+reasoning_trace:
+  - step: 1
+    input: "Request: Book a flight"
+    output: "Intent = travel_request"
+llm_profile:
+  id: GPT-4
+  version: 2025.3
+```
+
+### Expected Response
+
+```yaml
+reasoning_trace:
+  - step: 2
+    input: "Intent = travel_request"
+    output: "Proceed to flight search handler"
+auto_redirect:
+  type: module_call
+  next_module: flight_booking
+```
+
+## 9. Future Work
+
+Future extensions to AI-TCP may include:
+
+- Diagnostics packets (e.g., failure trace embedding)
+- Enhanced security & signature fields
+- Cross-LLM negotiation for task ownership
+- Lifecycle hooks for model confidence tracking

--- a/docs/rfc_drafts/refined/002_llm_compliance.md
+++ b/docs/rfc_drafts/refined/002_llm_compliance.md
@@ -1,0 +1,36 @@
+# RFC 002: LLM Compliance Layer in AI-TCP
+
+## 1. Overview
+This document defines the compliance requirements for Large Language Models (LLMs) participating in AI-TCP communication.
+
+## 2. Goals
+- Ensure consistent interpretation of YAML packets
+- Establish standard fields required by all LLMs
+- Enable future-proof trace and feedback handling
+
+## 3. Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `reasoning_trace` | array | Ordered log of internal logic |
+| `llm_profile` | object | Metadata about the participating LLM |
+| `auto_redirect` | object | Optional feedback routing structure |
+
+## 4. Validation Rules
+- Trace must be an ordered list with timestamps
+- `llm_profile.id` and `.version` are mandatory
+- `auto_redirect` must not overwrite prior trace context
+
+## 5. Example YAML
+```yaml
+reasoning_trace:
+  - step: 1
+    input: "Request: Determine action"
+    output: "Action: Evaluate"
+llm_profile:
+  id: GPT-4
+  version: 2025.3
+auto_redirect:
+  type: feedback
+  next_action: explain
+```

--- a/docs/rfc_drafts/refined/003_packet_definition.md
+++ b/docs/rfc_drafts/refined/003_packet_definition.md
@@ -1,0 +1,44 @@
+# RFC 003: AI-TCP Packet Structure Definition
+
+## 1. Purpose
+To formalize the structure and minimal required fields for any AI-TCP-compliant packet.
+
+## 2. Root Structure
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `graph_payload` | object | Embedded conceptual map (Mermaid) |
+| `reasoning_trace` | array | Historical reasoning log |
+| `meta` | object | Metadata (timestamp, origin, type) |
+| `llm_profile` | object | Describes source/target LLM |
+| `auto_redirect` | object | Optional continuation instruction |
+
+## 3. Constraints
+- All keys must be top-level YAML entries
+- Fields must not conflict or overwrite one another
+- `graph_payload.graph_structure` must start with `mmd:`
+
+## 4. Minimal Packet Example
+```yaml
+graph_payload:
+  graph_structure: |
+    mmd:flowchart TD
+    A --> B
+
+reasoning_trace:
+  - step: 1
+    input: Request received
+    output: Evaluating...
+
+meta:
+  timestamp: 2025-06-22T01:00:00Z
+  origin: system-core
+
+llm_profile:
+  id: GPT
+  version: 4.0
+
+auto_redirect:
+  type: feedback
+  next_action: halt
+```

--- a/docs/rfc_drafts/refined/004_reasoning_trace_structure.md
+++ b/docs/rfc_drafts/refined/004_reasoning_trace_structure.md
@@ -1,0 +1,64 @@
+# RFC 004: Reasoning Trace & Thought Chain Structure
+
+## 1. Purpose
+
+This document defines the internal structure and semantics of `reasoning_trace` used in AI-TCP packets, enabling traceability and chain-of-thought modeling among LLMs.
+
+## 2. Rationale
+
+To support explainable and auditable AI interactions, each LLM must expose its reasoning process in a standardized format. This RFC builds upon RFC 002 and defines additional structure, conventions, and interpretability guidance.
+
+## 3. Core Structure
+
+A `reasoning_trace` is an ordered array of steps.
+
+### Example:
+
+```yaml
+reasoning_trace:
+  - step: 1
+    input: "User requested a document summary"
+    output: "Identified task: summarization"
+  - step: 2
+    input: "Identified task: summarization"
+    output: "Delegating to summarization module"
+```
+
+## 4. Fields Per Step
+
+| Field   | Type   | Description                                |
+|---------|--------|--------------------------------------------|
+| `step`  | int    | Sequential identifier (1-based)            |
+| `input` | string | Observed or inherited state/context        |
+| `output`| string | Action, inference, or outcome at this step |
+
+## 5. Extended Semantics
+
+- Input/output should form a causal chain
+- The `output` of step N becomes the `input` of step N+1 (unless overridden)
+- Branching structures should be indicated explicitly via `fork:` or `condition:` (future RFC may expand)
+
+## 6. Integrity Rules
+
+- Steps must be strictly ordered (ascending `step`)
+- Missing `input` or `output` renders the trace invalid
+- Additional fields are permitted (e.g., `module`, `confidence`) but must not overwrite core semantics
+
+## 7. Interoperability
+
+To be interoperable across LLMs:
+
+- Each trace step must be interpretable independently
+- Ambiguity in field names or reasoning transitions must be avoided
+- Cross-model trace translation may be needed (see RFC 005: Diagnostics)
+
+## 8. Visualization Notes
+
+Future tooling may visualize reasoning chains using flowchart-like semantics.
+Trace logs may be converted into Mermaid for human inspection or debugging.
+
+## 9. Reference
+
+- RFC 001: AI-TCP Protocol Overview
+- RFC 002: LLM Compliance
+- RFC 003: Packet Structure Definition

--- a/docs/rfc_drafts/refined/README.md
+++ b/docs/rfc_drafts/refined/README.md
@@ -1,0 +1,8 @@
+# 📑 AI-TCP RFC Drafts
+
+| Title | Created | Summary |
+| ----- | ------- | ------- |
+| [RFC 001: AI-TCP Protocol Overview](001_ai_tcp_overview.md) | 2025-06-22 | AI-TCP is a lightweight, structured protocol for inter-AI communication using YAML, Graph Payloads (Mermaid), and traceable reasoning. |
+| [RFC 002: LLM Compliance Layer in AI-TCP](002_llm_compliance.md) | 2025-06-22 | This document defines the compliance requirements for Large Language Models (LLMs) participating in AI-TCP communication. |
+| [RFC 003: AI-TCP Packet Structure Definition](003_packet_definition.md) | 2025-06-22 | This document formalizes the structure and minimal required fields for AI-TCP-compliant packets. These packets serve as the atomic units of communication between LLMs under the AI-TCP protocol. |
+| [RFC 004: Reasoning Trace & Thought Chain Structure](004_reasoning_trace_structure.md) | 2025-06-22 | This document defines the internal structure and semantics of `reasoning_trace` used in AI-TCP packets, enabling traceability and chain-of-thought modeling among LLMs. |


### PR DESCRIPTION
## Summary
- fix Markdown formatting issues in RFC drafts
- output refined versions under `docs/rfc_drafts/refined`

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6857c0ffcbd0833381943fae9f666ec5