### PR TITLE
Add RFC 010 on AI‑TCP extension possibilities

### DIFF
--- a/docs/rfc_drafts/010_protocol_extension_possibilities.md
+++ b/docs/rfc_drafts/010_protocol_extension_possibilities.md
@@ -1,0 +1,62 @@
+# RFC 010: AI-TCP Protocol Extension Possibilities
+
+## 1. Purpose
+
+This RFC explores potential extensions to the AI-TCP protocol that enable richer communication among LLM-based agents while maintaining backward compatibility. The goal is to outline future features and establish guidelines for structured version management.
+
+## 2. Background
+
+AI-TCP currently provides a lightweight mechanism for inter-AI messaging. As the number of agents and interaction patterns grow, additional capabilities are required to share context, emotional nuance, and asynchronous exchanges without fragmenting the standard.
+
+## 3. Proposed Extensions
+
+### 3.1 Emotion Tags
+
+AI packets MAY include an optional `emotion_tags` field within metadata. These tags provide hints about the sender's tonal intent (e.g., `"encouraging"`, `"concerned"`). Receiving agents can interpret and respond accordingly, enabling empathetic dialog and more natural hand-offs.
+
+### 3.2 Prompt Inheritance Frame
+
+To facilitate iterative workflows, a `prompt_inheritance` section SHALL describe the lineage of prior prompts or tasks. Each entry specifies a parent prompt ID and transformation notes. This allows downstream agents to trace context history and build upon previous reasoning chains without explicit repetition.
+
+### 3.3 Asynchronous Processing Channel
+
+Agents MAY negotiate an asynchronous channel for tasks that do not require immediate responses. This channel operates alongside standard packet exchange and uses unique identifiers for correlating deferred results. It permits long-running operations or batch processing without blocking synchronous flows.
+
+## 4. Version Management
+
+### 4.1 Semantic Versioning
+
+The protocol specification SHALL adopt semantic versioning (`MAJOR.MINOR.PATCH`). Incrementing the MAJOR version indicates breaking changes; MINOR signals backward-compatible extensions; PATCH denotes clarifications or bug fixes.
+
+### 4.2 Compatibility Headers
+
+Every packet includes a `protocol_version` field. Agents MUST support at least the two most recent MAJOR versions and ignore unknown optional fields to maintain forward compatibility.
+
+### 4.3 Extension Registry
+
+A centralized registry tracks official extensions with unique identifiers and required protocol versions. Agents announce supported extensions during the handshake phase to negotiate shared capabilities.
+
+## 5. Potential Applications
+
+- **AI Contracts**: Agents can formalize agreements using prompt inheritance and emotion-tagged negotiations, ensuring traceable commitments.
+- **Shared Decision-Making**: Asynchronous channels enable collective deliberation, where multiple agents contribute reasoning steps over time.
+- **Contextual Memory Sharing**: Prompt inheritance facilitates long-term collaborations by preserving task lineage across sessions.
+
+## 6. Discussion
+
+These proposed features remain optional and modular. Implementers are encouraged to experiment and provide feedback on interoperability concerns. Backward compatibility strategies ensure existing deployments continue functioning as the protocol evolves.
+
+## 7. References
+
+- RFC 003: Packet Definition
+- RFC 007: Dynamic Context Flow
+- RFC 008: Interoperability & Extensibility
+
+## 8. Status
+
+Status: Draft
+Last Updated: 2025-07-15
+
+---
+
+End of RFC 010


### PR DESCRIPTION
## Summary
- propose new RFC 010 covering extension possibilities for AI‑TCP

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python validate_all.py` *(fails to complete due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6857c97afae88333a6478ec1f472f5e9