### PR TITLE
Add RFC 014 metadata format

### DIFF
--- a/docs/rfc_drafts/000_rfc_index.md
+++ b/docs/rfc_drafts/000_rfc_index.md
@@ -10,6 +10,7 @@ This index lists all RFC drafts currently available in the `docs/rfc_drafts/` di
 | 002    | LLM Compliance                    | Requirements for model compliance            |
 | 003    | AI-TCP Packet Format              | Packet structure and flow definition         |
 | 004    | Reasoning & Thought Chain Logging| Logging inference and reasoning paths        |
+| 014    | Unified Metadata Format          | Standardized metadata headers for packets   |
 
 ## 🛠️ Metadata
 

--- a/docs/rfc_drafts/014_metadata_format.md
+++ b/docs/rfc_drafts/014_metadata_format.md
@@ -1,0 +1,46 @@
+# RFC 014: Unified Metadata Format for AI-TCP Packets
+
+## 1. Introduction
+This RFC defines a unified metadata header used in all AI-TCP packets exchanged between Large Language Models (LLMs). A consistent metadata format simplifies validation, orchestration, and auditing across diverse nodes.
+
+## 2. Metadata Format
+The header is a YAML or JSON object placed at the beginning of every packet. Fields are case-sensitive and use `snake_case` naming.
+
+## 3. Required Fields
+| Field | Type | Description |
+|-------|------|-------------|
+| `llm_id` | string | Identifier of the generating or target LLM |
+| `language` | string | BCP-47 or ISO 639 language code for the payload |
+| `timestamp` | string | UTC timestamp in ISO 8601 format |
+| `compliance` | string | RFC or policy version that governs packet structure |
+
+## 4. Optional Fields
+| Field | Type | Description |
+|-------|------|-------------|
+| `trace_id` | string | Unique identifier for tracking across packets |
+| `role` | string | Agent role or capability tag |
+| `tags` | array of strings | Free-form labels for routing or auditing |
+
+## 5. Field Validation and Defaults
+- `llm_id` must match `[A-Za-z0-9._-]+`.
+- `language` defaults to `en` if omitted.
+- Invalid or missing `timestamp` values trigger rejection.
+- `compliance` defaults to `RFC003` if not provided.
+
+## 6. Usage in Validation and Orchestration
+AI-TCP orchestration layers SHALL validate these fields before further processing. Packets failing validation MAY be quarantined or returned with an error. The metadata header is also logged to the reasoning trace for audit purposes.
+
+## 7. Example Header
+```yaml
+meta:
+  llm_id: gpt-4
+  language: en
+  timestamp: 2025-06-22T00:00:00Z
+  compliance: RFC003
+  trace_id: abc123
+  role: assistant
+  tags: [demo, rfc014]
+```
+
+## 8. Status
+Draft – Last updated: 2025-06-22

--- a/docs/rfc_drafts/README.md
+++ b/docs/rfc_drafts/README.md
@@ -1,6 +1,15 @@
-# AI-TCP RFC Drafts
+# 📑 AI-TCP RFC Drafts
 
-- [001_ai_tcp_overview.md](001_ai_tcp_overview.md) - RFC 001: AI-TCP Protocol Overview (Updated: 2025-06-22)
-- [002_llm_compliance.md](002_llm_compliance.md) - RFC 002: LLM Compliance Layer in AI-TCP (Updated: 2025-06-22)
-- [003_packet_definition.md](003_packet_definition.md) - RFC 003: AI-TCP Packet Structure Definition (Updated: 2025-06-22)
-- [004_reasoning_trace_structure.md](004_reasoning_trace_structure.md) - RFC 004: Reasoning Trace & Thought Chain Structure (Updated: 2025-06-22)
+| Title | Created | Summary |
+| ----- | ------- | ------- |
+| [RFC Index: AI-TCP Project](000_rfc_index.md) | 2025-06-22 | This index lists all RFC drafts currently available in the `docs/rfc_drafts/` directory. |
+| [RFC 001: AI-TCP Protocol Overview](001_ai_tcp_overview.md) | 2025-06-22 | AI-TCP is a lightweight, structured protocol for inter-AI communication using YAML, Graph Payloads (Mermaid), and traceable reasoning. |
+| [RFC 002: LLM Compliance Layer in AI-TCP](002_llm_compliance.md) | 2025-06-22 | This document defines the compliance requirements for Large Language Models (LLMs) participating in AI-TCP communication. |
+| [📦 **[RFC草稿] `003_packet_definition.md` 構造草案**](003_packet_definition.md) | 2025-06-22 | ```markdown |
+| [RFC 004: Reasoning Trace & Thought Chain Structure](004_reasoning_trace_structure.md) | 2025-06-22 | This document defines the internal structure and semantics of `reasoning_trace` used in AI-TCP packets, enabling traceability and chain-of-thought modeling among LLMs. |
+| [RFC 005: Multi-AI Directive Protocol (MAIDP)](005_multi_ai_directive.md) | 2025-06-22 | Draft |
+| [RFC006: Protocol Trust Layer](006_trust_layer_protocol.md) | 2025-06-22 | This RFC defines the Protocol Trust Layer for the AI-TCP communication stack. The Trust Layer provides an abstraction for managing trust, verification, and auditability across interactions between AI agents, human stakeholders, and infrastructure components. |
+| [RFC 007: Dynamic Context Flow in AI-TCP](007_dynamic_context_flow.md) | 2025-06-22 | Dynamic Context Flow (DCF) defines a mechanism for real-time adjustment of shared memory and processing focus among collaborating AI agents in the AI-TCP protocol. This enables agents to shift priorities and maintain coherent interactions even when context changes rapidly. |
+| [RFC 008: Interoperability & Extensibility](008_interop_extensibility.md) | 2025-06-22 | This RFC defines the principles and structure for ensuring interoperability between diverse LLM systems and enabling extensibility within the AI-TCP framework. It aims to foster modularity, forward-compatibility, and seamless communication in multi-agent environments. |
+| [RFC 009: AI Operational Limits & Ethics](009_ai_operational_limits.md) | 2025-06-22 | This document defines operational limitations and ethical boundaries for AI agents functioning under the AI-TCP framework. It provides clear constraints, escalation protocols, and fallback behaviors in scenarios where AI behavior may affect humans, infrastructure, or systems with safety implications. |
+| [RFC 014: Unified Metadata Format for AI-TCP Packets](014_metadata_format.md) | Unknown | This RFC defines a unified metadata header used in all AI-TCP packets exchanged between Large Language Models (LLMs). A consistent metadata format simplifies validation, orchestration, and auditing across diverse nodes. |


### PR DESCRIPTION
## Summary
- add RFC 014 describing a unified metadata header
- reference the RFC in 000_rfc_index
- regenerate the RFC README listing

## Testing
- `python check_rfc_numbers.py`
- `python validate_all.py` *(fails: ModuleNotFoundError)*


------
https://chatgpt.com/codex/tasks/task_e_6857c9fcb7148333a2182461ec5b77ea