### PR TITLE
Add RFC 014 metadata header format

### DIFF
--- a/docs/rfc_drafts/000_rfc_index.md
+++ b/docs/rfc_drafts/000_rfc_index.md
@@ -17,7 +17,7 @@ This index lists all RFC drafts currently available in the `docs/rfc_drafts/` di
 | 009    | AI Operational Limits & Ethics    | Operational and ethical boundaries           |
 | 012    | AI Packet Conflict Resolution     | Mechanisms for resolving packet-level conflicts |
 | 013    | Obsidian Integration Schema       | Folder and linking conventions for vaults    |
-| 014    | Unified Metadata Format           | Standardized metadata headers for packets    |
+| 014    | Metadata Format Specification     | Standardized metadata headers for packets    |
 
 ## 🛠️ Metadata
 

--- a/docs/rfc_drafts/014_metadata_format.md
+++ b/docs/rfc_drafts/014_metadata_format.md
@@ -1,46 +1,82 @@
-# RFC 014: Unified Metadata Format for AI-TCP Packets
+# RFC 014: Metadata Format Specification
 
-## 1. Introduction
-This RFC defines a unified metadata header used in all AI-TCP packets exchanged between Large Language Models (LLMs). A consistent metadata format simplifies validation, orchestration, and auditing across diverse nodes.
+## 1. Overview
+This RFC defines the standard metadata header used in all AI-TCP packets. The header ensures every packet carries minimal routing, auditing, and processing information in a consistent manner.
 
-## 2. Metadata Format
-The header is a YAML or JSON object placed at the beginning of every packet. Fields are case-sensitive and use `snake_case` naming.
-
-## 3. Required Fields
+## 2. Required Fields
 | Field | Type | Description |
 |-------|------|-------------|
-| `llm_id` | string | Identifier of the generating or target LLM |
-| `language` | string | BCP-47 or ISO 639 language code for the payload |
-| `timestamp` | string | UTC timestamp in ISO 8601 format |
-| `compliance` | string | RFC or policy version that governs packet structure |
+| `packet_id` | string | Unique identifier for the packet |
+| `version` | string | Metadata format version identifier |
+| `sender_id` | string | Originating agent or system |
+| `recipient_id` | string | Intended recipient agent or system |
+| `timestamp_utc` | ISO 8601 | Coordinated Universal Time of packet creation |
+| `intent_category` | enum | One of: `trace`, `intent`, `conflict`, `confirm`, `meta` |
+| `priority_level` | integer | Priority from `0` (lowest) to `3` (highest) |
 
-## 4. Optional Fields
+## 3. Optional Fields
 | Field | Type | Description |
 |-------|------|-------------|
-| `trace_id` | string | Unique identifier for tracking across packets |
-| `role` | string | Agent role or capability tag |
-| `tags` | array of strings | Free-form labels for routing or auditing |
+| `response_to` | string | Packet ID that this message replies to |
+| `expires_in_sec` | integer | Time-to-live in seconds |
+| `tags` | list | Arbitrary labels for routing or filtering |
+| `location_hint` | string | Suggested geographic or network location |
+| `signature_hash` | string | Cryptographic hash or signature for verification |
 
-## 5. Field Validation and Defaults
-- `llm_id` must match `[A-Za-z0-9._-]+`.
-- `language` defaults to `en` if omitted.
-- Invalid or missing `timestamp` values trigger rejection.
-- `compliance` defaults to `RFC003` if not provided.
-
-## 6. Usage in Validation and Orchestration
-AI-TCP orchestration layers SHALL validate these fields before further processing. Packets failing validation MAY be quarantined or returned with an error. The metadata header is also logged to the reasoning trace for audit purposes.
-
-## 7. Example Header
-```yaml
-meta:
-  llm_id: gpt-4
-  language: en
-  timestamp: 2025-06-22T00:00:00Z
-  compliance: RFC003
-  trace_id: abc123
-  role: assistant
-  tags: [demo, rfc014]
+## 4. Partial JSON Schema
+```json
+{
+  "type": "object",
+  "required": [
+    "packet_id",
+    "version",
+    "sender_id",
+    "recipient_id",
+    "timestamp_utc",
+    "intent_category",
+    "priority_level"
+  ],
+  "properties": {
+    "packet_id": {"type": "string"},
+    "version": {"type": "string"},
+    "sender_id": {"type": "string"},
+    "recipient_id": {"type": "string"},
+    "timestamp_utc": {"type": "string", "format": "date-time"},
+    "intent_category": {
+      "type": "string",
+      "enum": ["trace", "intent", "conflict", "confirm", "meta"]
+    },
+    "priority_level": {"type": "integer", "minimum": 0, "maximum": 3},
+    "response_to": {"type": "string"},
+    "expires_in_sec": {"type": "integer"},
+    "tags": {"type": "array", "items": {"type": "string"}},
+    "location_hint": {"type": "string"},
+    "signature_hash": {"type": "string"}
+  }
+}
 ```
 
-## 8. Status
-Draft – Last updated: 2025-06-22
+## 5. YAML Usage Example
+```yaml
+meta:
+  packet_id: "pkt-001"
+  version: "1.0"
+  sender_id: "agent_A"
+  recipient_id: "agent_B"
+  timestamp_utc: "2025-07-01T12:00:00Z"
+  intent_category: intent
+  priority_level: 2
+  response_to: "pkt-000"
+  expires_in_sec: 3600
+  tags: [demo, rfc014]
+  location_hint: "eu-west"
+  signature_hash: "abc123def"
+```
+
+## 6. Notes
+- All required fields MUST appear in every metadata header.
+- Optional fields MAY be omitted if not applicable.
+- New fields can be added in future revisions, but implementations MUST ignore unknown keys for forward compatibility.
+- Versioning of the metadata format allows parsers to adapt to changes over time.
+
+*End of RFC 014*


### PR DESCRIPTION
## Summary
- detail the metadata header fields for AI-TCP packets
- update RFC index entry for RFC 014

## Testing
- `python validate_all.py` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python tools/validate_structured_yaml.py structured_yaml/master_schema_v1.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_685b247ea4f08333ab1528f7842ac615