### PR TITLE
Implement link map generator

### DIFF
--- a/AI-TCP_Structure/html_logs/intent_001.html
+++ b/AI-TCP_Structure/html_logs/intent_001.html
@@ -1,0 +1,1 @@
+<html><body>intent 001</body></html>

--- a/AI-TCP_Structure/html_logs/intent_003.html
+++ b/AI-TCP_Structure/html_logs/intent_003.html
@@ -1,0 +1,1 @@
+<html><body>intent 003</body></html>

--- a/AI-TCP_Structure/link_map.json
+++ b/AI-TCP_Structure/link_map.json
@@ -1,0 +1,17 @@
+{
+  "intent_001": {
+    "yaml": "AI-TCP_Structure/yaml/intent_001.yaml",
+    "mermaid": "AI-TCP_Structure/mermaid/intent_001.mmd.md",
+    "html": "AI-TCP_Structure/html_logs/intent_001.html"
+  },
+  "intent_002": {
+    "yaml": "AI-TCP_Structure/yaml/intent_002.yaml",
+    "mermaid": "AI-TCP_Structure/mermaid/intent_002.mmd.md",
+    "missing": true
+  },
+  "intent_003": {
+    "yaml": "AI-TCP_Structure/yaml/intent_003.yaml",
+    "html": "AI-TCP_Structure/html_logs/intent_003.html",
+    "missing": true
+  }
+}

--- a/AI-TCP_Structure/mermaid/intent_001.mmd.md
+++ b/AI-TCP_Structure/mermaid/intent_001.mmd.md
@@ -1,0 +1,2 @@
+graph TD;
+A-->B;

--- a/AI-TCP_Structure/mermaid/intent_002.mmd.md
+++ b/AI-TCP_Structure/mermaid/intent_002.mmd.md
@@ -1,0 +1,2 @@
+graph TD;
+A-->C;

--- a/AI-TCP_Structure/yaml/intent_001.yaml
+++ b/AI-TCP_Structure/yaml/intent_001.yaml
@@ -1,0 +1,2 @@
+id: intent_001
+name: test one

--- a/AI-TCP_Structure/yaml/intent_002.yaml
+++ b/AI-TCP_Structure/yaml/intent_002.yaml
@@ -1,0 +1,2 @@
+id: intent_002
+name: test two

--- a/AI-TCP_Structure/yaml/intent_003.yaml
+++ b/AI-TCP_Structure/yaml/intent_003.yaml
@@ -1,0 +1,2 @@
+id: intent_003
+name: test three

--- a/gen_link_map.go
+++ b/gen_link_map.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type Entry struct {
+	YAML    string `json:"yaml"`
+	Mermaid string `json:"mermaid,omitempty"`
+	HTML    string `json:"html,omitempty"`
+	Missing bool   `json:"missing,omitempty"`
+}
+
+func readID(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "id:") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "id:")), nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return "", fmt.Errorf("id not found in %s", path)
+}
+
+func main() {
+	yamlDir := flag.String("yaml", "yaml", "YAML directory")
+	mermaidDir := flag.String("mermaid", "mermaid", "Mermaid directory")
+	htmlDir := flag.String("html", "html_logs", "HTML logs directory")
+	output := flag.String("output", "link_map.json", "Output JSON file")
+	flag.Parse()
+
+	entries := make(map[string]Entry)
+
+	yamlFiles, err := filepath.Glob(filepath.Join(*yamlDir, "*.yaml"))
+	if err != nil {
+		log.Fatalf("glob yaml: %v", err)
+	}
+
+	for _, yf := range yamlFiles {
+		id, err := readID(yf)
+		if err != nil {
+			log.Printf("warning: %v", err)
+			continue
+		}
+		e := Entry{YAML: filepath.ToSlash(yf)}
+
+		mermaidPath := filepath.Join(*mermaidDir, id+".mmd.md")
+		if _, err := os.Stat(mermaidPath); err == nil {
+			e.Mermaid = filepath.ToSlash(mermaidPath)
+		} else {
+			log.Printf("missing mermaid for %s", id)
+			e.Missing = true
+		}
+
+		htmlPath := filepath.Join(*htmlDir, id+".html")
+		if _, err := os.Stat(htmlPath); err == nil {
+			e.HTML = filepath.ToSlash(htmlPath)
+		} else {
+			log.Printf("missing html for %s", id)
+			e.Missing = true
+		}
+
+		entries[id] = e
+	}
+
+	data, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		log.Fatalf("marshal json: %v", err)
+	}
+
+	if err := os.WriteFile(*output, data, 0644); err != nil {
+		log.Fatalf("write output: %v", err)
+	}
+	fmt.Printf("Wrote %s\n", *output)
+}


### PR DESCRIPTION
## Summary
- add sample `AI-TCP_Structure` folder with YAML, Mermaid, and HTML samples
- implement `gen_link_map.go` for mapping ids between YAML, Mermaid and HTML files

## Testing
- `go run gen_link_map.go -yaml AI-TCP_Structure/yaml -mermaid AI-TCP_Structure/mermaid -html AI-TCP_Structure/html_logs -output AI-TCP_Structure/link_map.json`

------
https://chatgpt.com/codex/tasks/task_e_685b43dc26c08333af7b39a747b54cb4