### PR TITLE
Add YAML semantics checker tool

### DIFF
--- a/AI-TCP_Structure/tools/README.md
+++ b/AI-TCP_Structure/tools/README.md
@@ -30,3 +30,8 @@ YAML で記述された意図定義を HTML/Mermaid/JSON へ変換できます�
   cd tools
   go run gen_link_map.go ../yaml ../html_logs ../graph ../link_map/map.json
   ```
+- **check_semantics.go**
+  ```bash
+  cd tools
+  go run check_semantics.go ../yaml/intent_001.yaml
+  ```

--- a/AI-TCP_Structure/tools/check_semantics.go
+++ b/AI-TCP_Structure/tools/check_semantics.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Component struct {
+	ID   string `yaml:"id"`
+	Name string `yaml:"name"`
+	Type string `yaml:"type"`
+}
+
+type Connection struct {
+	From  string `yaml:"from"`
+	To    string `yaml:"to"`
+	Label string `yaml:"label"`
+}
+
+type Intent struct {
+	ID          string       `yaml:"id"`
+	Name        string       `yaml:"name"`
+	Components  []Component  `yaml:"components"`
+	Connections []Connection `yaml:"connections"`
+}
+
+func loadIntent(path string) (*Intent, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var intent Intent
+	if err := yaml.Unmarshal(data, &intent); err != nil {
+		return nil, err
+	}
+	return &intent, nil
+}
+
+func checkIntent(path string, intent *Intent) {
+	compMap := make(map[string]Component)
+	for _, c := range intent.Components {
+		compMap[c.ID] = c
+	}
+
+	fromCount := make(map[string]int)
+	toCount := make(map[string]int)
+
+	for i, conn := range intent.Connections {
+		if conn.From != "" {
+			fromCount[conn.From]++
+			if c, ok := compMap[conn.From]; ok {
+				if c.Type == "source" {
+					log.Printf("ERROR %s: connection %d uses 'from' with source component '%s'", path, i+1, conn.From)
+				}
+			}
+		}
+		if conn.To != "" {
+			toCount[conn.To]++
+		}
+	}
+
+	for _, c := range intent.Components {
+		if c.Type == "response" && toCount[c.ID] == 0 {
+			log.Printf("ERROR %s: response component '%s' has no incoming connection", path, c.ID)
+		}
+	}
+
+	for _, c := range intent.Components {
+		if fromCount[c.ID] == 0 && toCount[c.ID] == 0 {
+			log.Printf("WARN %s: component '%s' defined but not used in connections", path, c.ID)
+		}
+	}
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatalf("Usage: %s <intent.yaml> [intent.yaml ...]", os.Args[0])
+	}
+	for _, path := range os.Args[1:] {
+		intent, err := loadIntent(path)
+		if err != nil {
+			log.Printf("Failed to load %s: %v", path, err)
+			continue
+		}
+		fmt.Printf("Checking %s\n", path)
+		checkIntent(path, intent)
+	}
+}


### PR DESCRIPTION
## Summary
- add `check_semantics.go` to verify YAML intent files
- document new tool in tools README

## Testing
- `gofmt -w check_semantics.go`
- `go build ./...` *(fails: proxy access is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685b57c3d1748333aee9cf78d7d57053