### PR TITLE
Add structure tree generator

### DIFF
--- a/AI-TCP_Structure/tools/README.md
+++ b/AI-TCP_Structure/tools/README.md
@@ -30,3 +30,8 @@ YAML で記述された意図定義を HTML/Mermaid/JSON へ変換できます�
   cd tools
   go run gen_link_map.go ../yaml ../html_logs ../graph ../link_map/map.json
   ```
+ - **gen_structure_tree.go**
+  ```bash
+  cd tools
+  go run gen_structure_tree.go .. ../../docs/poc_logs/structure_map.mmd.md
+  ```

--- a/AI-TCP_Structure/tools/gen_structure_tree.go
+++ b/AI-TCP_Structure/tools/gen_structure_tree.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func sanitize(path string) string {
+	s := strings.ReplaceAll(path, string(os.PathSeparator), "_")
+	s = strings.ReplaceAll(s, ".", "_")
+	s = strings.ReplaceAll(s, "-", "_")
+	return s
+}
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s <root_dir> <output_file>\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+	if flag.NArg() < 2 {
+		flag.Usage()
+		os.Exit(1)
+	}
+	rootDir := flag.Arg(0)
+	outputFile := flag.Arg(1)
+
+	var entries []struct {
+		rel   string
+		isDir bool
+	}
+
+	if err := filepath.WalkDir(rootDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if path == rootDir {
+			return nil
+		}
+		rel, err := filepath.Rel(rootDir, path)
+		if err != nil {
+			return err
+		}
+		entries = append(entries, struct {
+			rel   string
+			isDir bool
+		}{rel: rel, isDir: d.IsDir()})
+		return nil
+	}); err != nil {
+		log.Fatalf("walk: %v", err)
+	}
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].rel < entries[j].rel })
+
+	nodeSet := make(map[string]string)
+	edges := []string{}
+	rootID := "root"
+	nodeSet[rootID] = fmt.Sprintf("%s[\"%s\"]", rootID, filepath.Base(rootDir))
+
+	for _, e := range entries {
+		id := sanitize(e.rel)
+		label := filepath.Base(e.rel)
+		if e.isDir {
+			label += "/"
+		} else {
+			lower := strings.ToLower(label)
+			switch {
+			case strings.HasSuffix(lower, ".yaml") || strings.HasSuffix(lower, ".yml"):
+				label = "YAML: " + label
+			case strings.HasSuffix(lower, ".mmd.md") || strings.HasSuffix(lower, ".mmd"):
+				label = "Mermaid: " + label
+			case strings.HasSuffix(lower, ".md"):
+				label = "MD: " + label
+			}
+		}
+		nodeSet[id] = fmt.Sprintf("%s[\"%s\"]", id, label)
+
+		parent := filepath.Dir(e.rel)
+		parentID := rootID
+		if parent != "." {
+			parentID = sanitize(parent)
+		}
+		edges = append(edges, fmt.Sprintf("    %s --> %s", parentID, id))
+	}
+
+	nodes := make([]string, 0, len(nodeSet))
+	for _, v := range nodeSet {
+		nodes = append(nodes, "    "+v)
+	}
+	sort.Strings(nodes)
+
+	lines := []string{"```mermaid", "graph TD"}
+	lines = append(lines, nodes...)
+	lines = append(lines, edges...)
+	lines = append(lines, "```")
+
+	if err := os.MkdirAll(filepath.Dir(outputFile), 0755); err != nil {
+		log.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(outputFile, []byte(strings.Join(lines, "\n")), 0644); err != nil {
+		log.Fatalf("write: %v", err)
+	}
+	fmt.Printf("Generated %s\n", outputFile)
+}

--- a/AI-TCP_Structure/tools/go.mod
+++ b/AI-TCP_Structure/tools/go.mod
@@ -1,5 +1,5 @@
 module github.com/elementary-particles-Man/AI-TCP/tools
 
-go 1.24.2
+go 1.23
 
 require gopkg.in/yaml.v3 v3.0.1

--- a/docs/poc_logs/structure_map.mmd.md
+++ b/docs/poc_logs/structure_map.mmd.md
@@ -1,0 +1,52 @@
+```mermaid
+graph TD
+    graph["graph/"]
+    graph__gitkeep[".gitkeep"]
+    graph_intent_001_mmd_md["Mermaid: intent_001.mmd.md"]
+    html_logs["html_logs/"]
+    html_logs_intent_001_html["intent_001.html"]
+    html_logs_intent_003_html["intent_003.html"]
+    link_map["link_map/"]
+    link_map__gitkeep[".gitkeep"]
+    link_map_json["link_map.json"]
+    mermaid["mermaid/"]
+    mermaid_intent_001_mmd_md["Mermaid: intent_001.mmd.md"]
+    mermaid_intent_002_mmd_md["Mermaid: intent_002.mmd.md"]
+    root[".."]
+    tools["tools/"]
+    tools_README_md["MD: README.md"]
+    tools_gen_link_map_go["gen_link_map.go"]
+    tools_gen_structure_tree_go["gen_structure_tree.go"]
+    tools_go_mod["go.mod"]
+    tools_go_sum["go.sum"]
+    tools_yaml_to_html_go["yaml_to_html.go"]
+    tools_yaml_to_mermaid_go["yaml_to_mermaid.go"]
+    yaml["yaml/"]
+    yaml_intent_001_yaml["YAML: intent_001.yaml"]
+    yaml_intent_002_yaml["YAML: intent_002.yaml"]
+    yaml_intent_003_yaml["YAML: intent_003.yaml"]
+    root --> graph
+    graph --> graph__gitkeep
+    graph --> graph_intent_001_mmd_md
+    root --> html_logs
+    html_logs --> html_logs_intent_001_html
+    html_logs --> html_logs_intent_003_html
+    root --> link_map
+    root --> link_map_json
+    link_map --> link_map__gitkeep
+    root --> mermaid
+    mermaid --> mermaid_intent_001_mmd_md
+    mermaid --> mermaid_intent_002_mmd_md
+    root --> tools
+    tools --> tools_README_md
+    tools --> tools_gen_link_map_go
+    tools --> tools_gen_structure_tree_go
+    tools --> tools_go_mod
+    tools --> tools_go_sum
+    tools --> tools_yaml_to_html_go
+    tools --> tools_yaml_to_mermaid_go
+    root --> yaml
+    yaml --> yaml_intent_001_yaml
+    yaml --> yaml_intent_002_yaml
+    yaml --> yaml_intent_003_yaml
+```


### PR DESCRIPTION
## Summary
- generate Mermaid tree view of AI-TCP_Structure directories
- document usage in tools README
- lower Go version for local toolchain
- include generated example map

## Testing
- `GOTOOLCHAIN=local go run gen_structure_tree.go .. ../../docs/poc_logs/structure_map.mmd.md`


------
https://chatgpt.com/codex/tasks/task_e_685b57cbaf30833388de8cff22107d42