### PR TITLE
Add YAML semantics enrichment and graph label tools

### DIFF
--- a/AI-TCP_Structure/tools/README.md
+++ b/AI-TCP_Structure/tools/README.md
@@ -26,6 +26,12 @@ go run gen_structure_tree.go .. ../../docs/poc_logs/structure_map.mmd.md
 ✅ check_semantics.go
 cd tools
 go run check_semantics.go ../yaml/intent_001.yaml
+✅ enrich_yaml_semantics.go
+cd tools
+go run enrich_yaml_semantics.go ../yaml/intent_001.yaml ../enriched_yaml -description "Sample" -next intent_002
+✅ inject_graph_labels.go
+cd tools
+go run inject_graph_labels.go ../yaml/intent_001.yaml ../graph/intent_001.mmd.md ../graph_labeled/intent_001.mmd.md
 
 📝 .mmd.md ファイルは Mermaid 描画ブロックを含む Markdown 形式で出力され、Obsidian のライブプレビューで直接グラフとして描画可能です。
 リンクマップや構造ツリーと合わせて、Vault全体のトレース可視化が可能になります。

--- a/AI-TCP_Structure/tools/enrich_yaml_semantics.go
+++ b/AI-TCP_Structure/tools/enrich_yaml_semantics.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+func main() {
+	desc := flag.String("description", "", "Semantics description")
+	next := flag.String("next", "", "Recommended next intent id")
+	outDir := flag.String("out", "enriched_yaml", "Output directory")
+	flag.Parse()
+
+	if flag.NArg() < 1 {
+		log.Fatalf("Usage: %s <input.yaml> [options]", os.Args[0])
+	}
+	input := flag.Arg(0)
+
+	data, err := os.ReadFile(input)
+	if err != nil {
+		log.Fatalf("read input: %v", err)
+	}
+
+	m := make(map[string]interface{})
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		log.Fatalf("parse yaml: %v", err)
+	}
+
+	sem, ok := m["semantics"].(map[string]interface{})
+	if !ok {
+		sem = make(map[string]interface{})
+	}
+	if *desc != "" {
+		sem["description"] = *desc
+	}
+	if *next != "" {
+		sem["recommended_next"] = *next
+	}
+	if len(sem) > 0 {
+		m["semantics"] = sem
+	}
+
+	outPath := filepath.Join(*outDir, filepath.Base(input))
+	if err := os.MkdirAll(filepath.Dir(outPath), 0755); err != nil {
+		log.Fatalf("mkdir: %v", err)
+	}
+	outData, err := yaml.Marshal(m)
+	if err != nil {
+		log.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(outPath, outData, 0644); err != nil {
+		log.Fatalf("write: %v", err)
+	}
+	fmt.Printf("✅ Enriched YAML saved: %s\n", outPath)
+}

--- a/AI-TCP_Structure/tools/inject_graph_labels.go
+++ b/AI-TCP_Structure/tools/inject_graph_labels.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+func loadLabels(path string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var root struct {
+		Semantics struct {
+			Labels map[string]string `yaml:"labels"`
+		} `yaml:"semantics"`
+	}
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return nil, err
+	}
+	return root.Semantics.Labels, nil
+}
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s <intent.yaml> <input.mmd.md> <output.mmd.md>\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+	if flag.NArg() < 3 {
+		flag.Usage()
+		os.Exit(1)
+	}
+	yamlPath := flag.Arg(0)
+	inPath := flag.Arg(1)
+	outPath := flag.Arg(2)
+
+	labels, err := loadLabels(yamlPath)
+	if err != nil {
+		log.Fatalf("load labels: %v", err)
+	}
+
+	data, err := os.ReadFile(inPath)
+	if err != nil {
+		log.Fatalf("read mermaid: %v", err)
+	}
+	lines := regexp.MustCompile("\r?\n").Split(string(data), -1)
+	nodeRe := regexp.MustCompile(`^(\s*)([A-Za-z0-9_]+)\[\"([^\"]*)\"\](.*)`)
+
+	for i, line := range lines {
+		m := nodeRe.FindStringSubmatch(line)
+		if len(m) == 0 {
+			continue
+		}
+		id := m[2]
+		if lbl, ok := labels[id]; ok && lbl != "" {
+			lines[i] = fmt.Sprintf("%s%s[\"%s\"]%s", m[1], id, lbl, m[4])
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(outPath), 0755); err != nil {
+		log.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(outPath, []byte(strings.Join(lines, "\n")), 0644); err != nil {
+		log.Fatalf("write: %v", err)
+	}
+	fmt.Printf("✅ Labeled graph saved: %s\n", outPath)
+}


### PR DESCRIPTION
## Summary
- add `enrich_yaml_semantics.go` for injecting semantics metadata into YAML files
- add `inject_graph_labels.go` for adding labels from YAML semantics to Mermaid graphs
- document new tools with usage examples in `tools/README.md`

## Testing
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685b6628b8b08333aa4c8716a82bcce6