### PR TITLE
Add negotiation playground Go tools

### DIFF
--- a/AI-TCP_Structure/playground/agent_configs/agent_A.yaml
+++ b/AI-TCP_Structure/playground/agent_configs/agent_A.yaml
@@ -1,0 +1,12 @@
+id: agent_A
+name: Creative-AI
+role: proposal_initiator
+objectives:
+  - propose timestamp-based filenames
+  - prioritize automation speed
+constraints:
+  - filename must start with YYYYMMDD
+  - avoid verbose naming
+negotiation_behavior:
+  stance: prefer_timestamp_naming
+  fallback: accept_mediator_resolution

--- a/AI-TCP_Structure/playground/agent_configs/agent_B.yaml
+++ b/AI-TCP_Structure/playground/agent_configs/agent_B.yaml
@@ -1,0 +1,12 @@
+id: agent_B
+name: Maintenance-AI
+role: proposal_counter
+objectives:
+  - propose semantic filenames
+  - prioritize long-term clarity
+constraints:
+  - filename must include descriptive keyword
+  - avoid naming conflicts
+negotiation_behavior:
+  stance: prefer_semantic_naming
+  fallback: accept_mediator_resolution

--- a/AI-TCP_Structure/playground/agent_configs/agent_C.yaml
+++ b/AI-TCP_Structure/playground/agent_configs/agent_C.yaml
@@ -1,0 +1,12 @@
+id: agent_C
+name: Mediator-AI
+role: negotiation_mediator
+objectives:
+  - resolve conflicts between agents
+  - synthesize optimal solution
+constraints:
+  - remain neutral
+  - ensure consensus is reached
+negotiation_behavior:
+  stance: mediate_and_merge
+  fallback: escalate_to_human

--- a/AI-TCP_Structure/playground/dialogue_sample.txt
+++ b/AI-TCP_Structure/playground/dialogue_sample.txt
@@ -1,0 +1,3 @@
+AgentA: Propose using timestamp filenames.
+AgentB: Suggest using semantic names.
+AgentC: Offer hybrid solution.

--- a/AI-TCP_Structure/tools/gen_html_negotiation_log.go
+++ b/AI-TCP_Structure/tools/gen_html_negotiation_log.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+    "flag"
+    "html/template"
+    "log"
+    "os"
+    "path/filepath"
+
+    "gopkg.in/yaml.v3"
+)
+
+type Message struct {
+    Speaker string `yaml:"speaker"`
+    Text    string `yaml:"text"`
+}
+
+type Log struct {
+    ID       string    `yaml:"id"`
+    Messages []Message `yaml:"messages"`
+}
+
+const htmlTemplate = `<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8"><title>{{.ID}}</title>
+<style>
+table{border-collapse:collapse;width:100%}
+th,td{border:1px solid #ccc;padding:8px;text-align:left}
+th{background:#f2f2f2}
+</style>
+</head>
+<body>
+<h2>Negotiation Log: {{.ID}}</h2>
+<table>
+<tr><th>Speaker</th><th>Text</th></tr>
+{{range .Messages}}
+<tr><td>{{.Speaker}}</td><td>{{.Text}}</td></tr>
+{{end}}
+</table>
+</body>
+</html>`
+
+func main() {
+    input := flag.String("input", filepath.Join("yaml_logs", "log_test_case_001.yaml"), "input yaml log")
+    output := flag.String("output", filepath.Join("negotiation_logs", "negotiation_test.html"), "output html file")
+    flag.Parse()
+
+    data, err := os.ReadFile(*input)
+    if err != nil {
+        log.Fatalf("read input: %v", err)
+    }
+    var logData Log
+    if err := yaml.Unmarshal(data, &logData); err != nil {
+        log.Fatalf("unmarshal yaml: %v", err)
+    }
+
+    if err := os.MkdirAll(filepath.Dir(*output), 0755); err != nil {
+        log.Fatalf("make dir: %v", err)
+    }
+    f, err := os.Create(*output)
+    if err != nil {
+        log.Fatalf("create output: %v", err)
+    }
+    defer f.Close()
+
+    tmpl := template.Must(template.New("html").Parse(htmlTemplate))
+    if err := tmpl.Execute(f, logData); err != nil {
+        log.Fatalf("execute template: %v", err)
+    }
+    log.Printf("wrote %s", *output)
+}
+

--- a/AI-TCP_Structure/tools/gen_mermaid_negotiation.go
+++ b/AI-TCP_Structure/tools/gen_mermaid_negotiation.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+    "flag"
+    "fmt"
+    "log"
+    "os"
+    "path/filepath"
+    "strings"
+
+    "gopkg.in/yaml.v3"
+)
+
+type Message struct {
+    Speaker string `yaml:"speaker"`
+    Text    string `yaml:"text"`
+}
+
+type Log struct {
+    ID       string    `yaml:"id"`
+    Messages []Message `yaml:"messages"`
+}
+
+func main() {
+    input := flag.String("input", filepath.Join("yaml_logs", "log_test_case_001.yaml"), "input yaml log")
+    output := flag.String("output", filepath.Join("negotiation_logs", "negotiation_test.mmd.md"), "output mermaid file")
+    flag.Parse()
+
+    data, err := os.ReadFile(*input)
+    if err != nil {
+        log.Fatalf("read input: %v", err)
+    }
+    var logData Log
+    if err := yaml.Unmarshal(data, &logData); err != nil {
+        log.Fatalf("unmarshal yaml: %v", err)
+    }
+
+    var mmd strings.Builder
+    mmd.WriteString("graph TD\n")
+    for i, msg := range logData.Messages {
+        nodeID := fmt.Sprintf("n%d", i)
+        label := fmt.Sprintf("%s: %s", msg.Speaker, msg.Text)
+        mmd.WriteString(fmt.Sprintf("    %s[\"%s\"]\n", nodeID, label))
+        if i > 0 {
+            prev := fmt.Sprintf("n%d", i-1)
+            mmd.WriteString(fmt.Sprintf("    %s --> %s\n", prev, nodeID))
+        }
+    }
+
+    if err := os.MkdirAll(filepath.Dir(*output), 0755); err != nil {
+        log.Fatalf("make dir: %v", err)
+    }
+    if err := os.WriteFile(*output, []byte(mmd.String()), 0644); err != nil {
+        log.Fatalf("write output: %v", err)
+    }
+    log.Printf("wrote %s", *output)
+}
+

--- a/AI-TCP_Structure/tools/gen_yaml_trace_sample.go
+++ b/AI-TCP_Structure/tools/gen_yaml_trace_sample.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+    "bufio"
+    "flag"
+    "fmt"
+    "log"
+    "os"
+    "path/filepath"
+    "strings"
+
+    "gopkg.in/yaml.v3"
+)
+
+// Message represents a single dialogue line
+type Message struct {
+    Speaker string `yaml:"speaker"`
+    Text    string `yaml:"text"`
+}
+
+// Log represents a negotiation log
+type Log struct {
+    ID       string    `yaml:"id"`
+    Messages []Message `yaml:"messages"`
+}
+
+func main() {
+    input := flag.String("input", "dialogue_sample.txt", "input dialogue text")
+    output := flag.String("output", filepath.Join("yaml_logs", "log_test_case_001.yaml"), "output yaml log")
+    flag.Parse()
+
+    f, err := os.Open(*input)
+    if err != nil {
+        log.Fatalf("failed to open input: %v", err)
+    }
+    defer f.Close()
+
+    var msgs []Message
+    scanner := bufio.NewScanner(f)
+    for scanner.Scan() {
+        line := scanner.Text()
+        if len(line) == 0 {
+            continue
+        }
+        var speaker, text string
+        n, err := fmt.Sscanf(line, "%[^:]: %s", &speaker, &text)
+        if err != nil || n < 2 {
+            parts := strings.SplitN(line, ":", 2)
+            if len(parts) == 2 {
+                speaker = strings.TrimSpace(parts[0])
+                text = strings.TrimSpace(parts[1])
+            } else {
+                log.Printf("skip malformed line: %s", line)
+                continue
+            }
+        }
+        msgs = append(msgs, Message{Speaker: speaker, Text: text})
+    }
+    if err := scanner.Err(); err != nil {
+        log.Fatalf("scan input: %v", err)
+    }
+
+    logData := Log{ID: "log_test_case_001", Messages: msgs}
+
+    if err := os.MkdirAll(filepath.Dir(*output), 0755); err != nil {
+        log.Fatalf("make dir: %v", err)
+    }
+    outFile, err := os.Create(*output)
+    if err != nil {
+        log.Fatalf("create output: %v", err)
+    }
+    defer outFile.Close()
+
+    enc := yaml.NewEncoder(outFile)
+    enc.SetIndent(2)
+    if err := enc.Encode(logData); err != nil {
+        log.Fatalf("encode yaml: %v", err)
+    }
+    log.Printf("wrote %s", *output)
+}
+

--- a/AI-TCP_Structure/tools/validate_yaml_struct.go
+++ b/AI-TCP_Structure/tools/validate_yaml_struct.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+    "flag"
+    "fmt"
+    "log"
+    "os"
+    "gopkg.in/yaml.v3"
+)
+
+type Agent struct {
+    ID     string   `yaml:"id"`
+    Name   string   `yaml:"name"`
+    Role   string   `yaml:"role"`
+    Objectives []string `yaml:"objectives"`
+    Constraints []string `yaml:"constraints"`
+}
+
+func validateFile(path string) error {
+    data, err := os.ReadFile(path)
+    if err != nil {
+        return err
+    }
+    var a Agent
+    if err := yaml.Unmarshal(data, &a); err != nil {
+        return err
+    }
+    if a.ID == "" || a.Name == "" || a.Role == "" {
+        return fmt.Errorf("missing required fields")
+    }
+    return nil
+}
+
+func main() {
+    flag.Parse()
+    if flag.NArg() == 0 {
+        log.Fatal("provide yaml files to validate")
+    }
+    for _, f := range flag.Args() {
+        if err := validateFile(f); err != nil {
+            log.Printf("%s: invalid (%v)", f, err)
+        } else {
+            log.Printf("%s: OK", f)
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add base negotiation guidelines for Agent A/B/C in YAML
- implement Go tools to generate YAML traces, mermaid diagrams, HTML logs
- add validator for agent YAML structure
- include sample dialogue and placeholders in playground

## Testing
- `go run gen_yaml_trace_sample.go -input ../playground/dialogue_sample.txt -output ../playground/yaml_logs/log_test_case_001.yaml` *(fails: Go module download blocked)*
- `go run gen_mermaid_negotiation.go ...` *(fails: Go module download blocked)*
- `go run gen_html_negotiation_log.go ...` *(fails: Go module download blocked)*
- `go run validate_yaml_struct.go ...` *(fails: Go module download blocked)*


------
https://chatgpt.com/codex/tasks/task_e_685b911232a88333a76542e66941afc4