### PR TITLE
Generate updated link map

### DIFF
--- a/AI-TCP_Structure/link_map/map.json
+++ b/AI-TCP_Structure/link_map/map.json
@@ -1,0 +1,20 @@
+{
+  "intent_001": {
+    "yaml": "../yaml/intent_001.yaml",
+    "html": "../html_logs/intent_001.html",
+    "missing": true
+  },
+  "intent_002": {
+    "yaml": "../yaml/intent_002.yaml",
+    "missing": true
+  },
+  "intent_003": {
+    "yaml": "../yaml/intent_003.yaml",
+    "html": "../html_logs/intent_003.html",
+    "missing": true
+  },
+  "intent_007": {
+    "yaml": "../yaml/intent_007.yaml",
+    "missing": true
+  }
+}


### PR DESCRIPTION
## Summary
- run `gen_link_map.go` to build a new link map for YAML/HTML/graph artifacts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_685b9ce7d7588333892c657ddfb4f8ca