### PR TITLE
Generate HTML log for intent_007

### DIFF
--- a/AI-TCP_Structure/html_logs/intent_007.html
+++ b/AI-TCP_Structure/html_logs/intent_007.html
@@ -1,0 +1,50 @@
+
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Autonomous Negotiation Demo</title>
+  <style>
+    table { border-collapse: collapse; width: 100%; font-family: sans-serif; }
+    th, td { border: 1px solid #aaa; padding: 6px; text-align: left; }
+    th { background-color: #f0f0f0; }
+    caption { font-size: 1.2em; margin: 10px; font-weight: bold; }
+  </style>
+</head>
+<body>
+  <h2>Autonomous Negotiation Demo</h2>
+  <p></p>
+
+  <table>
+    <caption>🧱 Components</caption>
+    <tr><th>ID</th><th>Type</th><th>Label</th></tr>
+    
+    <tr><td>ai_agent_1</td><td>source</td><td>AI Agent 1</td></tr>
+    
+    <tr><td>ai_agent_2</td><td>source</td><td>AI Agent 2</td></tr>
+    
+    <tr><td>negotiation_module</td><td>process</td><td>Negotiation Engine</td></tr>
+    
+    <tr><td>consensus_validator</td><td>process</td><td>Consensus Validator</td></tr>
+    
+    <tr><td>outcome_response</td><td>response</td><td>Final Response</td></tr>
+    
+  </table>
+
+  <br>
+
+  <table>
+    <caption>🔗 Connections</caption>
+    <tr><th>From</th><th>To</th><th>Label</th></tr>
+    
+    <tr><td>ai_agent_1</td><td>negotiation_module</td><td></td></tr>
+    
+    <tr><td>ai_agent_2</td><td>negotiation_module</td><td></td></tr>
+    
+    <tr><td>negotiation_module</td><td>consensus_validator</td><td></td></tr>
+    
+    <tr><td>consensus_validator</td><td>outcome_response</td><td></td></tr>
+    
+  </table>
+</body>
+</html>

--- a/AI-TCP_Structure/tools/yaml_to_html.go
+++ b/AI-TCP_Structure/tools/yaml_to_html.go
@@ -8,12 +8,12 @@
 package main
 
 import (
+	"bufio"
 	"html/template"
 	"log"
 	"os"
 	"path/filepath"
-
-	"gopkg.in/yaml.v3"
+	"strings"
 )
 
 type Component struct {
@@ -34,6 +34,109 @@ type Intent struct {
 	Description string       `yaml:"description"`
 	Components  []Component  `yaml:"components"`
 	Connections []Connection `yaml:"connections"`
+}
+
+// parseSimpleYAML parses a minimal YAML structure without external dependencies.
+// It expects a top-level mapping with optional fields:
+// id, name/title, description, components, connections.
+// Components and connections are simple sequences of mappings.
+func parseSimpleYAML(path string) (Intent, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return Intent{}, err
+	}
+	defer file.Close()
+
+	var intent Intent
+	scanner := bufio.NewScanner(file)
+	var section string
+	var comp Component
+	var conn Connection
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		switch {
+		case line == "components:":
+			if comp.ID != "" || comp.Label != "" || comp.Type != "" {
+				intent.Components = append(intent.Components, comp)
+				comp = Component{}
+			}
+			section = "components"
+			continue
+		case line == "connections:":
+			if conn.From != "" || conn.To != "" || conn.Label != "" {
+				intent.Connections = append(intent.Connections, conn)
+				conn = Connection{}
+			}
+			section = "connections"
+			continue
+		}
+
+		if section == "components" {
+			if strings.HasPrefix(line, "- ") {
+				if comp.ID != "" || comp.Label != "" || comp.Type != "" {
+					intent.Components = append(intent.Components, comp)
+					comp = Component{}
+				}
+				line = strings.TrimPrefix(line, "- ")
+			}
+			if strings.HasPrefix(line, "id:") {
+				comp.ID = strings.TrimSpace(strings.TrimPrefix(line, "id:"))
+			} else if strings.HasPrefix(line, "name:") {
+				comp.Label = strings.TrimSpace(strings.TrimPrefix(line, "name:"))
+			} else if strings.HasPrefix(line, "type:") {
+				comp.Type = strings.TrimSpace(strings.TrimPrefix(line, "type:"))
+			} else if strings.HasPrefix(line, "label:") {
+				comp.Label = strings.TrimSpace(strings.TrimPrefix(line, "label:"))
+			}
+			continue
+		}
+
+		if section == "connections" {
+			if strings.HasPrefix(line, "- ") {
+				if conn.From != "" || conn.To != "" || conn.Label != "" {
+					intent.Connections = append(intent.Connections, conn)
+					conn = Connection{}
+				}
+				line = strings.TrimPrefix(line, "- ")
+			}
+			if strings.HasPrefix(line, "from:") {
+				conn.From = strings.TrimSpace(strings.TrimPrefix(line, "from:"))
+			} else if strings.HasPrefix(line, "to:") {
+				conn.To = strings.TrimSpace(strings.TrimPrefix(line, "to:"))
+			} else if strings.HasPrefix(line, "label:") {
+				conn.Label = strings.TrimSpace(strings.TrimPrefix(line, "label:"))
+			}
+			continue
+		}
+
+		// top-level fields
+		if strings.HasPrefix(line, "id:") {
+			intent.ID = strings.TrimSpace(strings.TrimPrefix(line, "id:"))
+		} else if strings.HasPrefix(line, "title:") {
+			intent.Title = strings.TrimSpace(strings.TrimPrefix(line, "title:"))
+		} else if strings.HasPrefix(line, "name:") {
+			intent.Title = strings.TrimSpace(strings.TrimPrefix(line, "name:"))
+		} else if strings.HasPrefix(line, "description:") {
+			intent.Description = strings.TrimSpace(strings.TrimPrefix(line, "description:"))
+		}
+	}
+
+	// append final pending entries
+	if comp.ID != "" || comp.Label != "" || comp.Type != "" {
+		intent.Components = append(intent.Components, comp)
+	}
+	if conn.From != "" || conn.To != "" || conn.Label != "" {
+		intent.Connections = append(intent.Connections, conn)
+	}
+
+	return intent, scanner.Err()
 }
 
 const htmlTemplate = `
@@ -81,13 +184,7 @@ func main() {
 	inputPath := os.Args[1]
 	outputPath := os.Args[2]
 
-	yamlFile, err := os.ReadFile(inputPath)
-	if err != nil {
-		log.Fatalf("Failed to read YAML: %v", err)
-	}
-
-	var intent Intent
-	err = yaml.Unmarshal(yamlFile, &intent)
+	intent, err := parseSimpleYAML(inputPath)
 	if err != nil {
 		log.Fatalf("Failed to parse YAML: %v", err)
 	}


### PR DESCRIPTION
## Summary
- add HTML log output for PoC intent_007
- update `yaml_to_html.go` to parse simple YAML without external modules

## Testing
- `go run yaml_to_html.go ../yaml/intent_007.yaml ../html_logs/intent_007.html`


------
https://chatgpt.com/codex/tasks/task_e_685b9cdcd1048333a471b949632a5409