### PR TITLE
Add Mermaid flowchart for dmc_mental_001

### DIFF
--- a/generated_mermaid/dmc_mental_001.mmd.md
+++ b/generated_mermaid/dmc_mental_001.mmd.md
@@ -1,0 +1,18 @@
+```mmd
+flowchart LR
+  root["root"]
+  root -->|has| n1["id"]
+  root -->|has| n2["timestamp"]
+  root -->|has| n3["lang"]
+  root -->|has| n4["phase"]
+  root -->|has| n5["agent"]
+  root -->|has| n6["tags"]
+  n6 -->|includes| n7["anxiety"]
+  n6 -->|includes| n8["screening"]
+  root -->|has| n9["meta"]
+  n9 -->|has| n10["version"]
+  n9 -->|has| n11["source"]
+  root -->|has| n12["data"]
+  n12 -->|has| n13["input"]
+  n12 -->|has| n14["output"]
+```


### PR DESCRIPTION
## Summary
- visualize the YAML structure of `dmc_mental_001` in Mermaid

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_685c01fbeae88333b1ce5e909182f2b2