### PR TITLE
Add generated JSON schema for DMC mental YAML

### DIFF
--- a/structured_yaml/schemas/dmc_mental_001.schema.json
+++ b/structured_yaml/schemas/dmc_mental_001.schema.json
@@ -1,0 +1,60 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "timestamp": {
+      "type": "string"
+    },
+    "lang": {
+      "type": "string"
+    },
+    "phase": {
+      "type": "string"
+    },
+    "agent": {
+      "type": "string"
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "meta": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        }
+      }
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "input": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "input",
+        "output"
+      ]
+    }
+  },
+  "required": [
+    "id",
+    "timestamp",
+    "lang",
+    "phase",
+    "data"
+  ],
+  "$schema": "http://json-schema.org/draft-07/schema#"
+}


### PR DESCRIPTION
## Summary
- generate JSON Schema for `dmc_mental_001` YAML

## Testing
- `python -m unittest discover -v` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_685c0204a99c8333a0a96c28efe6c36f