### PR TITLE
Add markdown narrative HTML converter

### DIFF
--- a/generated_html/narratives/dmc_session_20250618_analysis.html
+++ b/generated_html/narratives/dmc_session_20250618_analysis.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>dmc_session_20250618_analysis.md</title>
+  <style>
+/* File: html_templates/narrative_style.css */
+
+body {
+  font-family: sans-serif;
+  margin: 2rem;
+  background-color: #f9fafa;
+  color: #222;
+}
+
+main {
+  max-width: 800px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: #2a4b6e; /* calm blue tone */
+}
+
+a {
+  color: #1a5e9a;
+}
+
+pre {
+  background: #f4f4f4;
+  padding: 1em;
+  border-radius: 4px;
+  overflow-x: auto;
+}
+
+details {
+  margin-bottom: 1em;
+  padding: 0.5em;
+  border: 1px solid #ccc;
+  background-color: #fff;
+  border-radius: 4px;
+}
+
+  </style>
+  <script type="module">
+    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+    mermaid.initialize({ startOnLoad: true });
+  </script>
+</head>
+<body>
+  <main>
+    <details><summary>Table of Contents</summary>
+<ul>
+<ul>
+<li><a href="#dmc">DMCセッション分析レポート</a></li>
+<ul>
+<li><a href="#">セッション全体の構成と流れの要約</a></li>
+<li><a href="#phase">各Phaseの治療的意義と心理的効果</a></li>
+<ul>
+<li><a href="#phase-1">Phase 1: 共感と具体化</a></li>
+<li><a href="#phase-2">Phase 2: 自己受容と再構成</a></li>
+<li><a href="#phase-3">Phase 3: スキルの再評価</a></li>
+<li><a href="#phase-4">Phase 4: 肯定感の強化と次への橋渡し</a></li>
+</ul>
+<li><a href="#">心理療法的要素の指摘</a></li>
+</ul>
+</ul>
+</ul>
+</details>
+    <h2 id="dmc"><strong>DMCセッション分析レポート</strong></h2>
+
+<p>本レポートは、dmc\_reconstructed\_dialogue\_01に記録されたAI-ユーザー間の対話セッションについて、その構成、治療的フレームワーク、および内在する心理療法的技法を専門的観点から分析・解説するものである。</p>
+
+<h3 id=""><strong>セッション全体の構成と流れの要約</strong></h3>
+
+<p>本セッションは、クライアントが提示した漠然とした職務上のストレスという主訴に対し、構造化されたアプローチを用いて自己肯定感の回復と問題解決への動機付けを達成する、極めて論理的なプロセスを辿っている。セッションの流れは、導入部でのラポール形成と問題特定から始まり、中核部での認知の再構成と自己資源の再発見、そして終結部での肯定と行動変容への橋渡しという、標準的かつ効果的なカウンセリングのフローを忠実に再現している。クライアントの思考が、抽象的な「重圧感」から、具体的な自己の「強み」の認識へと、段階的かつ肯定的に変容していく様子が見て取れる。</p>
+
+<h3 id="phase"><strong>各Phaseの治療的意義と心理的効果</strong></h3>
+
+<h4 id="phase-1"><strong>Phase 1: 共感と具体化</strong></h4>
+
+<p>この初期フェーズは、治療的関係の基盤となるラポール形成に不可欠である。AIはまず、クライアントの苦痛を全面的に受容・共感する姿勢を示すことで、心理的な安全性と信頼感を醸成している。続く「どのような場面で最も強く感じられますか？」という問いは、漠然とした不安を具体的な問題へと外在化・客観視させるための第一歩であり、クライアントが自身の問題をより扱いやすい形で認識し始めることを促す効果を持つ。</p>
+
+<h4 id="phase-2"><strong>Phase 2: 自己受容と再構成</strong></h4>
+
+<p>セッションの核心部であり、支持的アプローチと認知行動療法的アプローチが巧みに統合されている。AIはまず、「孤独感と恐怖」というクライアントの感情を無条件に受容する。その上で、「間違えられない」という思考の背景にある自己信頼の揺らぎを指摘し、過去の成功体験の想起を促す。これは、クライアントが失っている自己効力感を再活性化させる試みである。さらに、クライアントの「後悔の念」を「誠実さ」とリフレーミングし、評価の焦点を「結果」から「行動プロセス」へとシフトさせている。これにより、完璧主義という認知の歪みを緩和し、自己評価の基準をより現実的でコントロール可能なものへと修正する効果が期待できる。</p>
+
+<h4 id="phase-3"><strong>Phase 3: スキルの再評価</strong></h4>
+
+<p>このフェーズは、認知の再構成をさらに一歩進める、強力なリフレーミングの段階である。クライアントが「泥臭いやり方」と自己卑下していた対処行動を、AIは「極めて論理的で優れたリスクマネジメント」という客観的かつ肯定的なスキルとして再定義（ラベリング）している。この介入は、クライアント自身が気づいていなかった、あるいは価値を置いていなかった自己の資源（リソース）を自覚させ、自己評価を根底から向上させる強力な心理的効果を持つ。</p>
+
+<h4 id="phase-4"><strong>Phase 4: 肯定感の強化と次への橋渡し</strong></h4>
+
+<p>終結フェーズとして、セッションで得られたポジティブな変化を一過性で終わらせないための重要なプロセスである。AIは、クライアントの中に芽生えた肯定的な感情を明確に言語化して強化（Affirmation）する。そして、その気づきを未来の行動へと繋げる提案（「プレッシャーを和らげるために活かす」）を行うことで、クライアントに内発的な動機付けを与え、セッションの継続とエンパワーメントを促進している。</p>
+
+<h3 id=""><strong>心理療法的要素の指摘</strong></h3>
+
+<p>本セッションには、複数の心理療法の要素が統合的に含まれている。</p>
+
+<ul>
+<li><strong>支持的カウンセリング要素:</strong></li>
+</ul>
+<p>* <strong>共感 (Empathy):</strong> セッション冒頭の「非常にお辛いですね」など、一貫してクライアントの感情に寄り添う姿勢が見られる。</p>
+<p>* <strong>受容 (Acceptance):</strong> Phase 2で、クライアントの孤独感や恐怖といったネガティブな感情を評価・判断せずに受け止めている。</p>
+<p>* <strong>肯定 (Affirmation):</strong> Phase 4における「その感覚を、今は大切にしてください」という言葉は、クライアントの体験そのものを肯定する強力な支持的介入である。</p>
+<ul>
+<li><strong>認知行動療法 (CBT) 的要素:</strong></li>
+</ul>
+<p>* <strong>認知の再構成 (Cognitive Restructuring):</strong> 本セッションで最も顕著な技法。Phase 2での「完璧主義」の捉え直しや、Phase 3での「泥臭い行動」を「リスクマネジメントスキル」と再定義する部分は、自動思考やスキーマに働きかける典型的なCBTアプローチである。</p>
+<p>* <strong>ソクラテス的問答法 (Socratic Questioning):</strong> AIは直接的なアドバイスをせず、「～な経験はありますか？」「～として認識したことはありましたか？」といった質問を投げかける。これにより、クライアント自身が内省を通じて結論や気づきに到達することを促しており、CBTにおける重要な対話技法と一致する。</p>
+<p>* <strong>行動への焦点化:</strong> 結果ではなく、具体的な「行動」に着目させる問いかけ（Phase 2）は、自己評価を行動レベルで具体化させ、問題解決志向を高める効果がある。</p>
+  </main>
+</body>
+</html>

--- a/html_templates/narrative_style.css
+++ b/html_templates/narrative_style.css
@@ -1,0 +1,37 @@
+/* File: html_templates/narrative_style.css */
+
+body {
+  font-family: sans-serif;
+  margin: 2rem;
+  background-color: #f9fafa;
+  color: #222;
+}
+
+main {
+  max-width: 800px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: #2a4b6e; /* calm blue tone */
+}
+
+a {
+  color: #1a5e9a;
+}
+
+pre {
+  background: #f4f4f4;
+  padding: 1em;
+  border-radius: 4px;
+  overflow-x: auto;
+}
+
+details {
+  margin-bottom: 1em;
+  padding: 0.5em;
+  border: 1px solid #ccc;
+  background-color: #fff;
+  border-radius: 4px;
+}

--- a/html_templates/narrative_template.html
+++ b/html_templates/narrative_template.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{ title }}</title>
+  <style>
+{{ style }}
+  </style>
+  <script type="module">
+    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+    mermaid.initialize({ startOnLoad: true });
+  </script>
+</head>
+<body>
+  <main>
+    {{ toc | safe }}
+    {{ content | safe }}
+  </main>
+</body>
+</html>

--- a/pytools/md_to_narrative_html.py
+++ b/pytools/md_to_narrative_html.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import sys
+import re
+from pathlib import Path
+import html
+
+# Try to import markdown libraries
+converter = None
+converter_type = None
+try:
+    import markdown2  # type: ignore
+
+    converter = lambda text: markdown2.markdown(
+        text, extras=["fenced-code-blocks", "header-ids"]
+    )
+    converter_type = "markdown2"
+except Exception:
+    try:
+        import mistune  # type: ignore
+
+        md = mistune.create_markdown()
+        converter = lambda text: md(text)
+        converter_type = "mistune"
+    except Exception:
+        converter = None
+
+# Paths relative to repository root
+TEMPLATE_DIR = Path("html_templates")
+TEMPLATE_FILE = "narrative_template.html"
+STYLE_FILE = "narrative_style.css"
+
+
+def simple_markdown_to_html(text: str):
+    """Very small Markdown to HTML converter returning html and heading list."""
+    lines = text.splitlines()
+    html_lines: list[str] = []
+    headings: list[tuple[int, str, str]] = []
+    list_open = False
+    code_open = False
+    code_lang = ""
+
+    def fmt_inline(t: str) -> str:
+        t = html.escape(t)
+        return re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", t)
+
+    def close_list():
+        nonlocal list_open
+        if list_open:
+            html_lines.append("</ul>")
+            list_open = False
+
+    for line in lines:
+        if line.startswith("```"):
+            if not code_open:
+                code_lang = line[3:].strip()
+                cls = "mermaid" if code_lang == "mermaid" else ""
+                html_lines.append(f'<pre class="{cls}">')
+                code_open = True
+            else:
+                html_lines.append("</pre>")
+                code_open = False
+            continue
+        if code_open:
+            html_lines.append(html.escape(line))
+            continue
+        m = re.match(r"^(#{1,6})\s+(.*)", line)
+        if m:
+            close_list()
+            level = len(m.group(1))
+            text_val = m.group(2).strip()
+            plain = re.sub(r"\*\*(.+?)\*\*", r"\1", text_val)
+            slug = re.sub(r"[^a-zA-Z0-9_-]+", "-", plain).strip("-").lower()
+            headings.append((level, slug, plain))
+            html_lines.append(
+                f'<h{level} id="{slug}">{fmt_inline(text_val)}</h{level}>'
+            )
+            continue
+        m = re.match(r"^[*+-]\s+(.*)", line)
+        if m:
+            if not list_open:
+                html_lines.append("<ul>")
+                list_open = True
+            html_lines.append(f"<li>{fmt_inline(m.group(1).strip())}</li>")
+            continue
+        close_list()
+        if line.strip() == "":
+            html_lines.append("")
+        else:
+            html_lines.append(f"<p>{fmt_inline(line.strip())}</p>")
+
+    close_list()
+    if code_open:
+        html_lines.append("</pre>")
+
+    return "\n".join(html_lines), headings
+
+
+def build_toc(headings: list[tuple[int, str, str]]) -> str:
+    """Build a nested HTML TOC from heading tuples."""
+    matches = headings
+    toc_parts: list[str] = ["<details><summary>Table of Contents</summary>"]
+    current_level = 0
+    for level, hid, text in matches:
+        while level > current_level:
+            toc_parts.append("<ul>")
+            current_level += 1
+        while level < current_level:
+            toc_parts.append("</ul>")
+            current_level -= 1
+        toc_parts.append(f'<li><a href="#{hid}">{text}</a></li>')
+    while current_level > 0:
+        toc_parts.append("</ul>")
+        current_level -= 1
+    toc_parts.append("</details>")
+    return "\n".join(toc_parts)
+
+
+def convert_file(md_path: Path, out_path: Path) -> None:
+    """Convert a Markdown file to styled HTML."""
+
+    template_text = (TEMPLATE_DIR / TEMPLATE_FILE).read_text(encoding="utf-8")
+    style_text = (TEMPLATE_DIR / STYLE_FILE).read_text(encoding="utf-8")
+
+    md_text = md_path.read_text(encoding="utf-8")
+    headings: list[tuple[int, str, str]]
+    if converter is None:
+        html_body, headings = simple_markdown_to_html(md_text)
+    else:
+        html_body = converter(md_text)
+        if converter_type == "mistune":
+            md_heads = re.findall(r"^(#{1,6})\s+(.*)", md_text, flags=re.MULTILINE)
+            headings = []
+            for hashes, text_val in md_heads:
+                level = len(hashes)
+                slug = re.sub(r"[^a-zA-Z0-9_-]+", "-", text_val).strip("-").lower()
+                pattern = rf"<h{level}>{re.escape(text_val)}</h{level}>"
+                repl = rf'<h{level} id="{slug}">{text_val}</h{level}>'
+                html_body = re.sub(pattern, repl, html_body, count=1)
+                headings.append((level, slug, text_val))
+        else:
+            matches = re.findall(r'<h([1-6]) id="([^\"]+)">(.*?)</h\1>', html_body)
+            headings = [(int(l), i, t) for l, i, t in matches]
+
+    toc_html = build_toc(headings)
+    html_text = (
+        template_text.replace("{{ title }}", md_path.name)
+        .replace("{{ style }}", style_text)
+        .replace("{{ toc | safe }}", toc_html)
+        .replace("{{ toc }}", toc_html)
+        .replace("{{ content | safe }}", html_body)
+        .replace("{{ content }}", html_body)
+    )
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(html_text, encoding="utf-8")
+    print(f"[OK] {md_path} -> {out_path}")
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: python pytools/md_to_narrative_html.py input.md [output.html]")
+        return
+    md_path = Path(sys.argv[1])
+    out_path = Path(sys.argv[2]) if len(sys.argv) >= 3 else md_path.with_suffix(".html")
+    convert_file(md_path, out_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create CSS/HTML templates for narrative output
- add Python tool `md_to_narrative_html.py`
- generate example narrative HTML

## Testing
- `python pytools/md_to_narrative_html.py analysis/dmc_session_20250618/dmc_session_20250618_analysis.md generated_html/narratives/dmc_session_20250618_analysis.html`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_685c84633a488333919253afe95a9f9f