### PR TITLE
Add CLI archive management script

### DIFF
--- a/scripts/manage_cli_archives.py
+++ b/scripts/manage_cli_archives.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Organize files in cli_archives.
+
+This script renames old task files with a timestamp and moves
+files older than 30 days into an ``old`` subdirectory.
+"""
+from __future__ import annotations
+import shutil
+from datetime import datetime, timedelta
+from pathlib import Path
+
+ARCHIVE_DIR = Path("cli_archives")
+OLD_DIR = ARCHIVE_DIR / "old"
+TARGET_FILES = [
+    "new_task.json",
+    "TaskValidation.txt",
+    "output.json",
+]
+
+
+def _timestamped_name(path: Path) -> Path:
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    return path.with_name(f"{path.stem}_{stamp}{path.suffix}")
+
+
+def rename_current_files() -> None:
+    """Rename specific files in ``ARCHIVE_DIR`` with a timestamp."""
+    for name in TARGET_FILES:
+        file_path = ARCHIVE_DIR / name
+        if file_path.exists():
+            file_path.rename(_timestamped_name(file_path))
+
+
+def move_old_files(days: int = 30) -> None:
+    """Move files older than ``days`` days to ``OLD_DIR``."""
+    threshold = datetime.now() - timedelta(days=days)
+    OLD_DIR.mkdir(parents=True, exist_ok=True)
+    for item in ARCHIVE_DIR.iterdir():
+        if item.is_file() and item.parent != OLD_DIR:
+            if datetime.fromtimestamp(item.stat().st_mtime) < threshold:
+                shutil.move(str(item), str(OLD_DIR / item.name))
+
+
+def main() -> None:
+    ARCHIVE_DIR.mkdir(parents=True, exist_ok=True)
+    rename_current_files()
+    move_old_files()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_manage_cli_archives.py
+++ b/tests/test_manage_cli_archives.py
@@ -1,0 +1,45 @@
+import os
+from pathlib import Path
+from datetime import datetime, timedelta
+
+import importlib.util
+
+spec = importlib.util.spec_from_file_location(
+    "manage_cli_archives", Path(__file__).parent.parent / "scripts" / "manage_cli_archives.py"
+)
+manage_cli_archives = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(manage_cli_archives)
+
+
+def test_rename_and_move(tmp_path):
+    archive = tmp_path / "cli_archives"
+    archive.mkdir()
+
+    # create target files
+    for name in manage_cli_archives.TARGET_FILES:
+        (archive / name).write_text("dummy")
+
+    # create an old file
+    old_file = archive / "old_file.txt"
+    old_file.write_text("old")
+    old_time = (datetime.now() - timedelta(days=31)).timestamp()
+    os.utime(old_file, (old_time, old_time))
+
+    # patch directories
+    manage_cli_archives.ARCHIVE_DIR = archive
+    manage_cli_archives.OLD_DIR = archive / "old"
+
+    manage_cli_archives.main()
+
+    # renamed files
+    assert not (archive / "new_task.json").exists()
+    assert not (archive / "TaskValidation.txt").exists()
+    assert not (archive / "output.json").exists()
+    assert len(list(archive.glob("new_task_*.json"))) == 1
+    assert len(list(archive.glob("TaskValidation_*.txt"))) == 1
+    assert len(list(archive.glob("output_*.json"))) == 1
+
+    # moved old file
+    moved = list((archive / "old").iterdir())
+    assert len(moved) == 1
+    assert moved[0].name == "old_file.txt"


### PR DESCRIPTION
## Summary
- add `manage_cli_archives.py` to rename task files with timestamp and move old files
- create tests for the new script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest tests/test_manage_cli_archives.py::test_rename_and_move -q`

------
https://chatgpt.com/codex/tasks/task_e_685fc817e6f083339fcafae54c02d6a7