### PR TITLE
Add archive utility scripts and enhance env updater

### DIFF
--- a/scripts/utils/clean_archives.py
+++ b/scripts/utils/clean_archives.py
@@ -12,17 +12,26 @@ def main() -> None:
     os.chdir(repo_root)
 
     parser = argparse.ArgumentParser(description="Clean old archives")
-    parser.add_argument("--keep", type=int, default=50, help="number of files to keep")
+    parser.add_argument("--keep", type=int, default=10, help="number of task entries to keep")
     args = parser.parse_args()
 
     archive_dir = Path("cli_archives")
     archive_dir.mkdir(parents=True, exist_ok=True)
 
-    files = [f for f in archive_dir.iterdir() if f.is_file()]
-    files.sort(key=lambda p: p.stat().st_mtime, reverse=True)
-    for f in files[args.keep:]:
-        f.unlink()
-        print(f"Removed {f}")
+    tasks = {}
+    for f in archive_dir.glob("new_task_*.json"):
+        ts = f.stem[len("new_task_") :]
+        tasks[ts] = f.stat().st_mtime
+
+    sorted_ts = sorted(tasks.items(), key=lambda x: x[1], reverse=True)
+    remove_ts = [ts for ts, _ in sorted_ts[args.keep:]]
+
+    for ts in remove_ts:
+        for file in archive_dir.glob(f"*{ts}*"):
+            print(f"Removing {file}")
+            file.unlink()
+
+    print(f"Cleanup complete. Kept {args.keep} tasks.")
 
 
 if __name__ == "__main__":

--- a/scripts/utils/cli_archive_checker.py
+++ b/scripts/utils/cli_archive_checker.py
@@ -1,0 +1,52 @@
+# scripts/utils/cli_archive_checker.py
+import os
+from pathlib import Path
+
+
+def main() -> None:
+    repo_root = os.environ.get("REPO_ROOT")
+    if not repo_root:
+        print("REPO_ROOT environment variable not set")
+        return
+    os.chdir(repo_root)
+
+    archive_dir = Path("cli_archives")
+    archive_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Scanning {archive_dir} ...")
+    files = [p for p in archive_dir.iterdir() if p.is_file()]
+    complete = set()
+    tasks = set()
+    for f in files:
+        name = f.name
+        if name.startswith("complete_") and name.endswith(".flag"):
+            ts = name[len("complete_"):-5]
+            complete.add(ts)
+            tasks.add(ts)
+        elif name.startswith("new_task_") and name.endswith(".json"):
+            ts = name[len("new_task_"):-5]
+            tasks.add(ts)
+
+    all_ok = True
+    for ts in sorted(tasks):
+        has_flag = ts in complete
+        has_task = any(p.name == f"new_task_{ts}.json" for p in files)
+        status = []
+        if has_flag and has_task:
+            status.append("OK")
+        else:
+            all_ok = False
+            if not has_flag:
+                status.append("missing complete.flag")
+            if not has_task:
+                status.append("missing new_task.json")
+        print(f"{ts}: {', '.join(status)}")
+
+    if all_ok:
+        print("All flag/task pairs are present.")
+    else:
+        print("Some pairs are missing.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/utils/update_env.py
+++ b/scripts/utils/update_env.py
@@ -1,6 +1,7 @@
 # scripts/utils/update_env.py
 import os
 from pathlib import Path
+from shutil import copy2
 
 
 def main() -> None:
@@ -11,18 +12,22 @@ def main() -> None:
     os.chdir(repo_root)
 
     env_path = Path(".env")
+    backup_path = env_path.with_suffix(env_path.suffix + ".bak")
+
     if env_path.exists():
         current = env_path.read_text(encoding="utf-8")
-        line = next((l for l in current.splitlines() if l.startswith("REPO_ROOT")), "")
+        line = next((l for l in current.splitlines() if l.startswith("REPO_ROOT=")), "")
         if line:
             print(f"Current {line}")
-        ans = input("Overwrite .env? (y/n): ")
+        ans = input("Update REPO_ROOT in .env? (y/n): ")
         if ans.lower() != "y":
             print("Abort")
             return
+        copy2(env_path, backup_path)
+        print(f"Backup created at {backup_path}")
 
     env_path.write_text(f"REPO_ROOT={repo_root}\n", encoding="utf-8")
-    print(f"Updated {env_path}")
+    print(".env updated successfully.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `cli_archive_checker.py` to verify archived tasks
- extend `clean_archives.py` for configurable retention and pair cleanup
- improve `update_env.py` with backup and confirmation

## Testing
- `python -m py_compile scripts/utils/cli_archive_checker.py scripts/utils/clean_archives.py scripts/utils/update_env.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861068baa1083338cf8d3fc27b90b88