### PR TITLE
Add AI-TCP security modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,5 @@ jobs:
           override: true
       - name: Run FFI Tests
         run: cargo test --test ffi_test
+      - name: Run FFI Security Tests
+        run: cargo test --test ffi_security_test

--- a/docs/RFC/AI-TCP_RFC_security.md
+++ b/docs/RFC/AI-TCP_RFC_security.md
@@ -1,0 +1,7 @@
+# AI-TCP Security RFC
+
+- Replay Attack Mitigation
+- Session Resumption Mechanism
+- Ephemeral Key Rotation
+- Signature Verification Flow
+- FFI Binding considerations

--- a/ffi/ffi_security_test.rs
+++ b/ffi/ffi_security_test.rs
@@ -1,0 +1,7 @@
+#[test]
+fn test_replay_attack_guard() {
+    use rust_core::replay_attack_guard::ReplayAttackGuard;
+    let mut guard = ReplayAttackGuard::new();
+    assert_eq!(guard.is_replay(1), false);
+    assert_eq!(guard.is_replay(1), true);
+}

--- a/logs/work_results.txt
+++ b/logs/work_results.txt
@@ -1,3 +1,3 @@
 result: OK
-summary: "AI-TCP Bootstrap modules generated: RFC, FlatBuffers schema, Session Manager, Packet Validator, FFI test, CI step added."
+summary: "AI-TCP Spec expanded: Session Resumption, Replay Guard, RFC Security Draft, FFI Security Test, CI added."
 timestamp: "(投入時刻)"

--- a/src/replay_attack_guard.rs
+++ b/src/replay_attack_guard.rs
@@ -1,0 +1,18 @@
+use std::collections::HashSet;
+
+pub struct ReplayAttackGuard {
+    seen_sequence: HashSet<u64>,
+}
+
+impl ReplayAttackGuard {
+    pub fn new() -> Self { Self { seen_sequence: HashSet::new() } }
+
+    pub fn is_replay(&mut self, seq: u64) -> bool {
+        if self.seen_sequence.contains(&seq) {
+            true
+        } else {
+            self.seen_sequence.insert(seq);
+            false
+        }
+    }
+}

--- a/src/session_resumption.rs
+++ b/src/session_resumption.rs
@@ -1,0 +1,16 @@
+use x25519_dalek::{EphemeralSecret, PublicKey};
+use rand::rngs::OsRng;
+
+pub struct SessionResumption {
+    pub old_public: PublicKey,
+    pub new_private: EphemeralSecret,
+    pub new_public: PublicKey,
+}
+
+impl SessionResumption {
+    pub fn new(old_public: PublicKey) -> Self {
+        let new_private = EphemeralSecret::new(OsRng);
+        let new_public = PublicKey::from(&new_private);
+        Self { old_public, new_private, new_public }
+    }
+}


### PR DESCRIPTION
## Summary
- add session resumption helper
- implement replay attack guard
- document security concepts
- extend CI to run FFI security tests
- log work results

Generated by OpenAI Codex

------
https://chatgpt.com/codex/tasks/task_e_6872b1f4dbdc8333a50c59cd7a72b637