### PR TITLE
Add simple Go HTTP server module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module aitcp_server
+
+go 1.20

--- a/main.go
+++ b/main.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+// APIRequest defines the expected structure of the incoming JSON payload.
+type APIRequest struct {
+	TaskID  string `json:"task_id"`
+	Payload string `json:"payload"`
+}
+
+// APIResponse defines the structure of a successful response.
+type APIResponse struct {
+	Status           string `json:"status"`
+	ReceivedTaskID   string `json:"received_task_id"`
+	ProcessedPayload string `json:"processed_payload"`
+}
+
+// ErrorResponse defines the structure for error messages.
+type ErrorResponse struct {
+	Status string `json:"status"`
+	Error  string `json:"error"`
+}
+
+func apiHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "method not allowed"})
+		return
+	}
+
+	var req APIRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "invalid JSON"})
+		return
+	}
+
+	if req.TaskID == "" || req.Payload == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(ErrorResponse{Status: "error", Error: "task_id and payload are required"})
+		return
+	}
+
+	resp := APIResponse{
+		Status:           "success",
+		ReceivedTaskID:   req.TaskID,
+		ProcessedPayload: req.Payload,
+	}
+	json.NewEncoder(w).Encode(resp)
+}
+
+func main() {
+	http.HandleFunc("/api", apiHandler)
+	log.Println("starting server on :8080")
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		log.Fatalf("server failed: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- implement a new Go module for a basic HTTP server
- define `/api` POST handler parsing JSON with `task_id` and `payload`
- respond with success or error JSON

## Testing
- `go build main.go`


------
https://chatgpt.com/codex/tasks/task_e_6872b35d2ff48333bc6fc6bb7d0e85d6