### PR TITLE
Add Go JSON API server module

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+)
+
+type APIRequest struct {
+	TaskID  string `json:"task_id"`
+	Payload string `json:"payload"`
+}
+
+type APIResponse struct {
+	Status           string `json:"status"`
+	ReceivedTaskID   string `json:"received_task_id"`
+	ProcessedPayload string `json:"processed_payload"`
+}
+
+func apiHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(w, `{"status":"error","message":"Invalid request method"}`, http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req APIRequest
+	decoder := json.NewDecoder(r.Body)
+	err := decoder.Decode(&req)
+	if err != nil {
+		http.Error(w, `{"status":"error","message":"Invalid JSON payload"}`, http.StatusBadRequest)
+		return
+	}
+
+	resp := APIResponse{
+		Status:           "success",
+		ReceivedTaskID:   req.TaskID,
+		ProcessedPayload: req.Payload,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+func main() {
+	http.HandleFunc("/api", apiHandler)
+	fmt.Println("Starting server on :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/logs/work_results.txt
+++ b/logs/work_results.txt
@@ -1,3 +1,3 @@
 result: OK
-summary: "AI-TCP Spec expanded: Session Resumption, Replay Guard, RFC Security Draft, FFI Security Test, CI added."
+summary: "AI-TCP Goモジュール基盤 (JSON受信HTTPサーバー) を生成しました。"
 timestamp: "(投入時刻)"


### PR DESCRIPTION
## Summary
- add simple Go JSON API server in `go/main.go`
- record result in `logs/work_results.txt`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872b4348d408333a558c11fbc34884e