### PR TITLE
Implement ephemeral session resumption

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Check FlatBuffers schema
+        run: flatc --strict-json --proto ./flatbuffers/ephemeral_session.fbs
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/docs/RFC/AI-TCP_RFC_security.md
+++ b/docs/RFC/AI-TCP_RFC_security.md
@@ -5,3 +5,11 @@
 - Ephemeral Key Rotation
 - Signature Verification Flow
 - FFI Binding considerations
+
+## Session Resumption
+
+The protocol allows resuming a dropped connection using an ephemeral key exchange. The FlatBuffers schema `ephemeral_session.fbs` describes the resumption request containing the `session_id`, the client's new public key and an expiration timestamp.
+
+Upon receiving a resumption request the server rotates its own ephemeral key pair. It verifies the old public key associated with the session and responds with a new key. The resumed handshake mirrors the initial Diffie-Hellman exchange but binds the resumed connection to the original `session_id`.
+
+This key rotation limits exposure of any long-lived credentials while still enabling seamless continuation of an interrupted session.

--- a/flatbuffers/ephemeral_session.fbs
+++ b/flatbuffers/ephemeral_session.fbs
@@ -1,0 +1,9 @@
+namespace aitcp;
+
+table EphemeralSession {
+  session_id: string;
+  public_key: [ubyte];
+  expiration_unix: ulong;
+}
+
+root_type EphemeralSession;

--- a/logs/work_results.txt
+++ b/logs/work_results.txt
@@ -1,3 +1,3 @@
 result: OK
-summary: "AI-TCP Secure API /api/secure endpoint, Python client & test, RFC updated, CI step added."
+summary: "Ephemeral Session FlatBuffers schema, Rust resumption struct, Python client, RFC Security updated, CI added."
 timestamp: "(投入時刻)"

--- a/python/session_resumption.py
+++ b/python/session_resumption.py
@@ -1,0 +1,10 @@
+import requests
+import json
+
+
+def resume_session(session_id: str, old_pubkey: str):
+    url = "http://127.0.0.1:8080/api/resume"
+    headers = {"Content-Type": "application/json"}
+    data = {"session_id": session_id, "old_pubkey": old_pubkey}
+    response = requests.post(url, data=json.dumps(data), headers=headers)
+    return response.json()

--- a/src/ephemeral_resumption.rs
+++ b/src/ephemeral_resumption.rs
@@ -1,0 +1,22 @@
+use x25519_dalek::{EphemeralSecret, PublicKey};
+use rand::rngs::OsRng;
+
+pub struct EphemeralResumption {
+    pub session_id: String,
+    pub old_public: PublicKey,
+    pub new_private: EphemeralSecret,
+    pub new_public: PublicKey,
+}
+
+impl EphemeralResumption {
+    pub fn new(session_id: String, old_public: PublicKey) -> Self {
+        let new_private = EphemeralSecret::new(OsRng);
+        let new_public = PublicKey::from(&new_private);
+        Self {
+            session_id,
+            old_public,
+            new_private,
+            new_public,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- define `ephemeral_session.fbs` for session resumption
- implement Rust `EphemeralResumption` struct
- add Python resumption client helper
- document session resumption flow in the security RFC
- run FlatBuffers check in CI

## Testing
- `pytest -q` *(fails: connection refused)*
- `cargo test --test ffi_test` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_6872c5c7f31c833383bd5d559e744fd3