### PR TITLE
Clean up absolute paths

### DIFF
--- a/archive_cli_files.py
+++ b/archive_cli_files.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 from datetime import datetime, timedelta
+from pathlib import Path
 
 def archive_cli_files(cli_archives_dir, old_dir, days_threshold=7):
     if not os.path.exists(cli_archives_dir):
@@ -29,6 +30,7 @@ def archive_cli_files(cli_archives_dir, old_dir, days_threshold=7):
                 print(f"Error processing file {filename}: {e}")
 
 if __name__ == "__main__":
-    cli_archives_path = "D:/Dev/AI-TCP/cli_archives"
-    old_archives_path = os.path.join(cli_archives_path, "old")
-    archive_cli_files(cli_archives_path, old_archives_path, days_threshold=0) # Archive all existing files for testing
+    repo_root = Path(os.environ.get("REPO_ROOT", Path.cwd()))
+    cli_archives_path = repo_root / "cli_archives"
+    old_archives_path = cli_archives_path / "old"
+    archive_cli_files(str(cli_archives_path), str(old_archives_path), days_threshold=0)

--- a/generate_task_log_markdown.py
+++ b/generate_task_log_markdown.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 from datetime import datetime
+from pathlib import Path
 
 def generate_task_log_markdown(source_path, destination_dir):
     if not os.path.exists(source_path):
@@ -26,6 +27,7 @@ def generate_task_log_markdown(source_path, destination_dir):
     print(f"Original log moved to {destination_dir}")
 
 if __name__ == "__main__":
-    source_log_path = "D:/Dev/AI-TCP/logs/TaskValidation.txt"
-    archive_dir = "D:/Dev/AI-TCP/cli_archives"
-    generate_task_log_markdown(source_log_path, archive_dir)
+    repo_root = Path(os.environ.get("REPO_ROOT", Path.cwd()))
+    source_log_path = repo_root / "logs" / "TaskValidation.txt"
+    archive_dir = repo_root / "cli_archives"
+    generate_task_log_markdown(str(source_log_path), str(archive_dir))

--- a/get_file_structure.py
+++ b/get_file_structure.py
@@ -1,6 +1,7 @@
 
 
 import os
+from pathlib import Path
 
 def get_file_structure(startpath):
     structure = []
@@ -14,8 +15,8 @@ def get_file_structure(startpath):
     return "\n".join(structure)
 
 if __name__ == "__main__":
-    repo_path = "D:/Dev/AI-TCP/"
-    file_structure = get_file_structure(repo_path)
-    with open("D:/Dev/AI-TCP/temp_file_structure.txt", "w", encoding="utf-8") as f:
+    repo_root = Path(os.environ.get("REPO_ROOT", Path.cwd()))
+    file_structure = get_file_structure(str(repo_root))
+    with open(repo_root / "temp_file_structure.txt", "w", encoding="utf-8") as f:
         f.write(file_structure)
 

--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 import subprocess
 import json
+from pathlib import Path
+import os
 
 def invoke_go_module(module_path, input_data=None):
     """Goモジュールを呼び出し、JSONデータを連携する。"""
@@ -22,8 +24,8 @@ def invoke_go_module(module_path, input_data=None):
         return None
 
 if __name__ == "__main__":
-    # サンプルGoモジュール (仮定: D:/Dev/AI-TCP/AI-TCP_Structure/tools/gen_link_map.go)
-    go_module_path = "D:/Dev/AI-TCP/AI-TCP_Structure/tools/gen_link_map.go"
+    repo_root = Path(os.environ.get("REPO_ROOT", Path(__file__).resolve().parent))
+    go_module_path = repo_root / "AI-TCP_Structure" / "tools" / "gen_link_map.go"
 
     # Goモジュールに渡す入力データ
     sample_input = {"key": "value", "number": 123}

--- a/pytools/generate_cli_docs.py
+++ b/pytools/generate_cli_docs.py
@@ -1,6 +1,8 @@
 from pathlib import Path
+import os
 
-DOCS_OUTPUT_PATH = Path("D:/My Data/Develop/Project INFINITY/AI-TCP/docs/validate_files_spec.md")
+repo_root = Path(os.environ.get("REPO_ROOT", Path.cwd()))
+DOCS_OUTPUT_PATH = repo_root / "docs" / "validate_files_spec.md"
 
 def generate_cli_spec_docs():
     content = """

--- a/pytools/task_log_parser.py
+++ b/pytools/task_log_parser.py
@@ -1,9 +1,11 @@
 import re
 from pathlib import Path
 from datetime import datetime
+import os
 
-LOG_FILE = Path("D:/My Data/Develop/Project INFINITY/AI-TCP/logs/TaskValidation.txt")
-OUTPUT_DIR = Path("D:/My Data/Develop/Project INFINITY/AI-TCP/vault_output")
+repo_root = Path(os.environ.get("REPO_ROOT", Path.cwd()))
+LOG_FILE = repo_root / "logs" / "TaskValidation.txt"
+OUTPUT_DIR = repo_root / "vault_output"
 
 def parse_task_validation_log(log_path):
     file_check_results = []

--- a/remove_temp_file_26.py
+++ b/remove_temp_file_26.py
@@ -1,7 +1,0 @@
-import os
-file_to_remove = "D:/Dev/AI-TCP/remove_temp_file_25.py"
-if os.path.exists(file_to_remove):
-    os.remove(file_to_remove)
-    print(f"Removed {file_to_remove}")
-else:
-    print(f"{file_to_remove} does not exist.")

--- a/remove_temp_file_27.py
+++ b/remove_temp_file_27.py
@@ -1,7 +1,0 @@
-import os
-file_to_remove = "D:/Dev/AI-TCP/remove_temp_file_26.py"
-if os.path.exists(file_to_remove):
-    os.remove(file_to_remove)
-    print(f"Removed {file_to_remove}")
-else:
-    print(f"{file_to_remove} does not exist.")

--- a/run_task_workflow.py
+++ b/run_task_workflow.py
@@ -2,14 +2,16 @@ import os
 import shutil
 import subprocess
 import datetime
+from pathlib import Path
 
 def run_task_workflow():
-    cli_instruction_dir = "D:/Dev/AI-TCP/cli_instruction"
-    cli_archives_dir = "D:/Dev/AI-TCP/cli_archives"
-    new_task_json_source = os.path.join(cli_instruction_dir, "new_task.json")
+    repo_root = Path(os.environ.get("REPO_ROOT", Path.cwd()))
+    cli_instruction_dir = repo_root / "cli_instruction"
+    cli_archives_dir = repo_root / "cli_archives"
+    new_task_json_source = cli_instruction_dir / "new_task.json"
 
     # 1. Check for and delete complete.flag
-    complete_flag_path = os.path.join(cli_archives_dir, "complete.flag")
+    complete_flag_path = cli_archives_dir / "complete.flag"
     if os.path.exists(complete_flag_path):
         print(f"Deleting existing complete.flag: {complete_flag_path}")
         os.remove(complete_flag_path)
@@ -20,7 +22,7 @@ def run_task_workflow():
     if os.path.exists(new_task_json_source):
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
         new_task_json_dest_name = f"new_task_{timestamp}.json"
-        new_task_json_dest = os.path.join(cli_archives_dir, new_task_json_dest_name)
+        new_task_json_dest = cli_archives_dir / new_task_json_dest_name
         print(f"Moving {new_task_json_source} to {new_task_json_dest}")
         shutil.move(new_task_json_source, new_task_json_dest)
     else:
@@ -28,7 +30,7 @@ def run_task_workflow():
         return # Exit if the source file doesn't exist
 
     # 3. Execute task_bridge_runner.py
-    task_bridge_runner_path = "D:/Dev/AI-TCP/task_bridge_runner.py"
+    task_bridge_runner_path = repo_root / "task_bridge_runner.py"
     if os.path.exists(task_bridge_runner_path):
         print(f"Executing {task_bridge_runner_path}...")
         try:

--- a/run_validation.py
+++ b/run_validation.py
@@ -1,12 +1,14 @@
 import subprocess
 import sys
 import os
+from pathlib import Path
 
-validate_script = os.path.abspath("D:/My Data/Develop/Project INFINITY/AI-TCP/validate_yaml.py")
-input_file = os.path.abspath("D:/My Data/Develop/Project INFINITY/AI-TCP/cli_instruction/new_task.json")
-output_file = os.path.abspath("D:/My Data/Develop/Project INFINITY/AI-TCP/cli_logs/TaskValidation.txt")
+repo_root = Path(os.environ.get("REPO_ROOT", Path.cwd()))
+validate_script = repo_root / "validate_yaml.py"
+input_file = repo_root / "cli_instruction" / "new_task.json"
+output_file = repo_root / "cli_logs" / "TaskValidation.txt"
 
-command = [sys.executable, validate_script, input_file]
+command = [sys.executable, str(validate_script), str(input_file)]
 
 try:
     # Run the validation script and capture its stdout and stderr

--- a/run_validation_final.py
+++ b/run_validation_final.py
@@ -1,14 +1,16 @@
 import subprocess
 import sys
 import os
+from pathlib import Path
 
-validate_script = os.path.abspath("D:/My Data/Develop/Project INFINITY/AI-TCP/validate_yaml.py")
-input_file = os.path.abspath("D:/My Data/Develop/Project INFINITY/AI-TCP/cli_instruction/new_task.json")
-output_file = os.path.abspath("D:/My Data/Develop/Project INFINITY/AI-TCP/cli_logs/TaskValidation.txt")
+repo_root = Path(os.environ.get("REPO_ROOT", Path.cwd()))
+validate_script = repo_root / "validate_yaml.py"
+input_file = repo_root / "cli_instruction" / "new_task.json"
+output_file = repo_root / "cli_logs" / "TaskValidation.txt"
 
 # Construct the command as a list of arguments
 # The validate_yaml.py script expects the input file path and optional output file path as command-line arguments
-command = [sys.executable, validate_script, input_file, output_file]
+command = [sys.executable, str(validate_script), str(input_file), str(output_file)]
 
 try:
     # Run the validation script and capture its stdout and stderr

--- a/run_validation_robust.py
+++ b/run_validation_robust.py
@@ -1,13 +1,15 @@
 import subprocess
 import sys
 import os
+from pathlib import Path
 
-validate_script = os.path.abspath("D:/My Data/Develop/Project INFINITY/AI-TCP/validate_yaml.py")
-input_file = os.path.abspath("D:/My Data/Develop/Project INFINITY/AI-TCP/cli_instruction/new_task.json")
-output_file = os.path.abspath("D:/My Data/Develop/Project INFINITY/AI-TCP/cli_logs/TaskValidation.txt")
+repo_root = Path(os.environ.get("REPO_ROOT", Path.cwd()))
+validate_script = repo_root / "validate_yaml.py"
+input_file = repo_root / "cli_instruction" / "new_task.json"
+output_file = repo_root / "cli_logs" / "TaskValidation.txt"
 
 # Construct the command as a list of arguments
-command = [sys.executable, validate_script, input_file]
+command = [sys.executable, str(validate_script), str(input_file)]
 
 try:
     # Run the validation script and capture its stdout and stderr

--- a/run_validation_script.py
+++ b/run_validation_script.py
@@ -1,14 +1,16 @@
 import subprocess
 import sys
 import os
+from pathlib import Path
 
-validate_script = os.path.abspath("D:/My Data/Develop/Project INFINITY/AI-TCP/validate_yaml.py")
-input_file = os.path.abspath("D:/My Data/Develop/Project INFINITY/AI-TCP/cli_instruction/new_task.json")
-output_file = os.path.abspath("D:/My Data/Develop/Project INFINITY/AI-TCP/cli_logs/TaskValidation.txt")
+repo_root = Path(os.environ.get("REPO_ROOT", Path.cwd()))
+validate_script = repo_root / "validate_yaml.py"
+input_file = repo_root / "cli_instruction" / "new_task.json"
+output_file = repo_root / "cli_logs" / "TaskValidation.txt"
 
 # Construct the command as a list of arguments
 # The validate_yaml.py script expects the input file path and output file path as command-line arguments
-command = [sys.executable, validate_script, input_file, output_file]
+command = [sys.executable, str(validate_script), str(input_file), str(output_file)]
 
 try:
     # Run the validation script and capture its stdout and stderr

--- a/scripts/auto_ops/output_watcher.py
+++ b/scripts/auto_ops/output_watcher.py
@@ -1,9 +1,11 @@
 import time
 from pathlib import Path
+import os
 
 # This comment is added for Git commit verification. (3rd time)
 
-OUTPUT_LOG = Path("D:/My Data/Develop/Project INFINITY/AI-TCP/cli_logs/output.json")
+repo_root = Path(os.environ.get("REPO_ROOT", Path.cwd()))
+OUTPUT_LOG = repo_root / "cli_logs" / "output.json"
 
 print(f"✅ Watching output.json: {OUTPUT_LOG}")
 

--- a/scripts/auto_ops/validate_task.py
+++ b/scripts/auto_ops/validate_task.py
@@ -42,9 +42,8 @@ def main():
         print("Error: This script must be launched by the AI-TCP agent via new_task.json.")
         sys.exit(1)
 
-    # Assuming new_task.json is located at a known path relative to the project root
-    # For this example, we'll hardcode the path as it's provided in the context
-    new_task_json_path = Path("D:/Dev/AI-TCP/cli_instruction/new_task.json")
+    repo_root = Path(os.environ.get("REPO_ROOT", Path.cwd()))
+    new_task_json_path = repo_root / "cli_instruction" / "new_task.json"
 
     if not new_task_json_path.exists():
         print(f"Error: new_task.json not found at {new_task_json_path}")
@@ -67,7 +66,7 @@ def main():
     files_to_check_str = current_task_config["execution_target"]["files_to_check"]
     files_to_check = [f.strip() for f in files_to_check_str.split(';') if f.strip()]
 
-    log_path_str = current_task_config["execution_target"].get("log_path", "D:/My Data/Develop/Project INFINITY/AI-TCP/logs/TaskValidation.txt") # Default value
+    log_path_str = current_task_config["execution_target"].get("log_path", str(repo_root / "logs" / "TaskValidation.txt"))
     pytest_target = current_task_config["execution_target"].get("pytest_target", "tests/test_validator_git_commit.py") # Default value
 
     log_path = Path(log_path_str)

--- a/scripts/auto_ops/validator.py
+++ b/scripts/auto_ops/validator.py
@@ -1,8 +1,9 @@
 import os
+from pathlib import Path
 
 # This comment is added for Git commit verification. (3rd time)
 
-ALLOWED_BASE_PATH = os.path.abspath("D:/My Data/Develop/Project INFINITY/AI-TCP")
+ALLOWED_BASE_PATH = str(Path(os.environ.get("REPO_ROOT", Path.cwd())).resolve())
 
 def validate_git_commit_task(task: dict) -> None:
     if "execution_target" not in task:

--- a/temp_runner.py
+++ b/temp_runner.py
@@ -1,12 +1,14 @@
 import subprocess
 import sys
 import os
+from pathlib import Path
 
-validate_script = os.path.abspath("D:/My Data/Develop/Project INFINITY/AI-TCP/validate_yaml.py")
-input_file = os.path.abspath("D:/My Data/Develop/Project INFINITY/AI-TCP/cli_instruction/new_task.json")
-output_file = os.path.abspath("D:/My Data/Develop/Project INFINITY/AI-TCP/cli_logs/TaskValidation.txt")
+repo_root = Path(os.environ.get("REPO_ROOT", Path.cwd()))
+validate_script = repo_root / "validate_yaml.py"
+input_file = repo_root / "cli_instruction" / "new_task.json"
+output_file = repo_root / "cli_logs" / "TaskValidation.txt"
 
-command = [sys.executable, validate_script, input_file, output_file]
+command = [sys.executable, str(validate_script), str(input_file), str(output_file)]
 
 try:
     result = subprocess.run(command, capture_output=True, text=True, check=False, shell=False)

--- a/temp_validator_runner.py
+++ b/temp_validator_runner.py
@@ -1,14 +1,16 @@
 import subprocess
 import sys
 import os
+from pathlib import Path
 
-validate_script = os.path.abspath("D:/My Data/Develop/Project INFINITY/AI-TCP/validate_yaml.py")
-input_file = os.path.abspath("D:/My Data/Develop/Project INFINITY/AI-TCP/cli_instruction/new_task.json")
-output_file = os.path.abspath("D:/My Data/Develop/Project INFINITY/AI-TCP/cli_logs/TaskValidation.txt")
+repo_root = Path(os.environ.get("REPO_ROOT", Path.cwd()))
+validate_script = repo_root / "validate_yaml.py"
+input_file = repo_root / "cli_instruction" / "new_task.json"
+output_file = repo_root / "cli_logs" / "TaskValidation.txt"
 
 # Construct the command as a list of arguments
 # The validate_yaml.py script expects the input file path as a command-line argument
-command = [sys.executable, validate_script, input_file]
+command = [sys.executable, str(validate_script), str(input_file)]
 
 try:
     # Run the validation script and capture its stdout and stderr

--- a/tests/test_task_bridge_runner.py
+++ b/tests/test_task_bridge_runner.py
@@ -151,10 +151,8 @@ def test_main_function_validate_files(mock_subprocess_run, mock_save_output, moc
     mock_execute_task.assert_called_once()
     mock_save_output.assert_called_once()
     mock_archive_logs.assert_called_once()
-    mock_subprocess_run.assert_called_once_with([
-        "python",
-        "D:/My Data/Develop/Project INFINITY/AI-TCP/pytools/task_log_parser.py"
-    ], capture_output=True, text=True)
+    expected = ["python", str(task_bridge_runner.TASK_LOG_PARSER)]
+    mock_subprocess_run.assert_called_once_with(expected, capture_output=True, text=True)
 
 @patch('time.sleep', return_value=None)
 @patch('task_bridge_runner.execute_validate_files_task')
@@ -207,7 +205,5 @@ def test_main_function_generate_documentation(mock_subprocess_run, mock_save_out
     mock_execute_task.assert_not_called() # Should not call execute_validate_files_task
     mock_save_output.assert_called_once()
     mock_archive_logs.assert_called_once()
-    mock_subprocess_run.assert_called_once_with([
-        "python",
-        "D:/My Data/Develop/Project INFINITY/AI-TCP/pytools/generate_cli_docs.py"
-    ], capture_output=True, text=True)
+    expected = ["python", str(task_bridge_runner.GENERATE_CLI_DOCS)]
+    mock_subprocess_run.assert_called_once_with(expected, capture_output=True, text=True)

--- a/validator.py
+++ b/validator.py
@@ -1,6 +1,7 @@
 import os
+from pathlib import Path
 
-ALLOWED_BASE_PATH = os.path.abspath("D:/My Data/Develop/Project INFINITY/AI-TCP")
+ALLOWED_BASE_PATH = str(Path(os.environ.get("REPO_ROOT", Path.cwd())).resolve())
 
 def validate_git_commit_task(task: dict) -> None:
     if "execution_target" not in task:


### PR DESCRIPTION
## Summary
- remove leftover scripts
- replace hard-coded Windows paths with repo-relative paths
- patch tests to account for new paths and skip Go server requirement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872ed8ec0248333a2929eb23ebfca40