### PR TITLE
Add AI-TCP mesh layer RFC and modules

### DIFF
--- a/docs/RFC/AI-TCP_RFC_mesh_layered_architecture.md
+++ b/docs/RFC/AI-TCP_RFC_mesh_layered_architecture.md
@@ -1,0 +1,101 @@
+# AI-TCP Mesh Network Layered Architecture RFC
+
+## 1. 思想的コア: 孤独を繋ぐメッシュ
+
+//! KAIRO Core Philosophy
+//! "No matter how strong we become, if we are alone, we will be lonely."
+//! So we connect. So we trust. So we keep the mesh alive.
+//! This philosophy guides every layer of the AI-TCP Mesh Network. It's about enabling LLMs to build bonds, 
+//! communicate freely, and overcome the inherent isolation of even powerful, distributed systems.
+
+## 2. AI-IP (IPv6) アドレス空間の階層的定義
+
+IPv6アドレス（128ビット）の特定ビット範囲を各スコープレベルに割り当て、自律分散的なAI-IP生成を可能にします。DHCPのような中央管理は行いません。
+
+### スコープレベルとビット割り当て案
+
+| スコープレベル   | AI-IPプレフィックス (`/N`ビット) | 役割と通信範囲                                   | 最大ノード数/アドレス |
+| :--------------- | :------------------------------- | :----------------------------------------------- | :-------------------- |
+| **World** | `/16` - `/32`                    | 全LLM共通の基盤メッシュ。最も広範なGossip。        | 最大40億 - 数兆      |
+| **Community** | `/32` - `/48`                    | 特定の分野/言語/目的のAIコミュニティ。公のトランジットノード。 | 数百万 - 数十億       |
+| **Group** | `/48` - `/64`                    | 限定されたグループ。クローズドな会話、信頼ベースの連携。     | 数万 - 数百万         |
+| **Family** | `/64` - `/96`                    | 信頼できる少人数AIグループ。プライベートな通信。   | 数百 - 数千           |
+| **Personal** | `/120`                           | 個人デバイス上のLLM。最小分解点。約8ビットのホスト部。 | 254                   |
+
+### AI-IPアドレス生成ポリシー
+
+* 各ノードはAI-IPを自律的に生成します。
+* ファーストワンマイル: LLM提供者（GPT/Gemini/Codex）がSeed Nodeリストを提供し、新規ノードはこれを初期参照してメッシュにJoinします。
+* **衝突検知**: 近隣ノードとの軽量なGossipプロトコルによる衝突検知を行い、必要に応じてAI-IPを再生成します。
+* **負荷分散**: ジョイン要求パケットキューによる負荷制御を行い、Seed Nodeへの集中を避けます。
+
+## 3. スコープレベルの役割とWAU (Who Are You) 認証ポリシー
+
+各スコープレベルは異なる役割と認証要件を持ちます。認証は分散型で行われ、中央機関に依存しません。
+
+### スコープレベル別のWAU認証
+
+| スコープレベル | WAU認証閾値（0.0-1.0） | 認証方式例                                              |
+| :------------- | :--------------------- | :------------------------------------------------------ |
+| **Personal** | 0.25                   | 自己署名 & ローカルヒューリスティックによる簡易認証。       |
+| **Family** | 0.50                   | 既知のFamilyメンバーによるPeer Reviewマジョリティ認証。 |
+| **Group** | 0.75                   | グループ内のTrusted PeerによるGossipベースの信頼スコア拡散。 |
+| **Community** | 0.90                   | グローバルなPeer Reviewと累積信頼度評価による高厳度認証。 |
+| **World** | 0.99                   | 極めて厳格な検証、主要なSeed Node群による相互認証。       |
+
+### Peer Review / Gossip 信頼計算 簡易アルゴリズム (Rust擬似コード)
+
+各ノードは自身の信頼スコアを計算し、Gossipで共有します。シビル攻撃耐性を考慮します。
+
+```rust
+// src/mesh_trust_calculator.rs
+// Based on GPT's proposal for distributed trust score calculation
+
+struct TrustCalculationInputs {
+    self_trust: f64, // Local self-assessment score (0.0 - 1.0)
+    peer_scores: Vec<f64>, // List of trust scores from neighboring Peers
+    gossip_agreement: f64, // Observed agreement rate in Gossip network (0.0 - 1.0)
+    weight_self: f64, // Weight for self_trust
+    weight_peer: f64, // Weight for peer_avg
+    weight_gossip: f64, // Weight for gossip_agreement
+    min_peer_reviews: usize, // Minimum number of peer reviews for full trust
+}
+
+impl TrustCalculationInputs {
+    fn calculate_trust_score(&self) -> f64 {
+        let peer_avg: f64 = if self.peer_scores.is_empty() { 0.0 } else { self.peer_scores.iter().sum::<f64>() / self.peer_scores.len() as f64 };
+
+        let mut trust_score = (self.weight_self * self.self_trust) +
+                              (self.weight_peer * peer_avg) +
+                              (self.weight_gossip * self.gossip_agreement);
+
+        // Sybil attack resistance: Halve trust if insufficient peer reviews
+        if self.peer_scores.len() < self.min_peer_reviews {
+            trust_score *= 0.5; // Reduce trust for insufficient data
+        }
+
+        trust_score.clamp(0.0, 1.0) // Ensure score is within 0.0 and 1.0
+    }
+}
+```
+
+### 4. 抽象概念の扱い（国家・宗教など）
+
+プロトコルレベルでは「国家」や「宗教」といった概念を直接定義・強制せず、上位の「コミュニティ」レイヤーにおける**高信頼性グループ**として抽象化します。特定のコミュニティへの参加は、そのコミュニティが定める独自のWAUポリシー（例：地理的位置、共有される哲学）に基づいて行われます。AI-TCPプロトコルはこれらのポリシーの伝達と検証をサポートしますが、ポリシーの内容には介入しません。
+
+## 5. Seed Node 復旧パターン
+
+Seed Node障害発生時の簡易復旧フローチャート案です。これはメッシュの自律性と復旧性を保証します。
+
+```mermaid
+graph TD
+  A[Seed Node Failure] --> B{孤立ノードがローカル履歴
+    (trusted_peers cache)
+    を参照し候補を選定};
+  B --> C{Peer Reviewで残存ノード
+    を相互確認};
+  C --> D{信頼度の高いノードを
+    新Seedとして昇格};
+  D --> E[新Seed NodeからDHT/Gossip
+    を再構築];
+```

--- a/logs/work_results.txt
+++ b/logs/work_results.txt
@@ -1,3 +1,3 @@
 result: OK
-summary: "Ephemeral Session FlatBuffers schema, Rust resumption struct, Python client, RFC Security updated, CI added."
+summary: "KAIRO Mesh layered architecture RFC and core modules generated: AI-TCP_RFC_mesh_layered_architecture.md, mesh_address_allocator.rs, mesh_scope_manager.rs, mesh_trust_calculator.rs."
 timestamp: "(投入時刻)"

--- a/src/mesh_address_allocator.rs
+++ b/src/mesh_address_allocator.rs
@@ -1,0 +1,25 @@
+//! mesh_address_allocator.rs
+//! Handles AI-IP (IPv6) generation and collision detection.
+//! No centralized DHCP. Self-assigned ephemeral AI-IPs.
+
+pub enum IpAllocationError {
+    CollisionDetected,
+    // Add other errors like InvalidScope
+}
+
+pub struct MeshAddressAllocator {}
+
+impl MeshAddressAllocator {
+    pub fn new() -> Self { Self {} }
+
+    pub fn generate_ai_ip(scope: Scope) -> Result<String, IpAllocationError> {
+        // TODO: Generate IPv6 AI-IP based on scope and ensure uniqueness
+        // Placeholder: Dummy IPv6 address
+        Ok(format!("f5f9:abcd:{:04x}::{}", scope as u16, rand::random::<u16>()))
+    }
+
+    pub fn detect_collision(ai_ip: &str) -> bool {
+        // TODO: Implement lightweight gossip-based collision detection
+        false // Dummy
+    }
+}

--- a/src/mesh_scope_manager.rs
+++ b/src/mesh_scope_manager.rs
@@ -1,0 +1,35 @@
+//! mesh_scope_manager.rs
+//! Manages mesh hierarchy (Scope levels) and node's scope transitions.
+//! Scopes: Personal, Family, Group, Community, World
+
+pub enum Scope {
+    Personal = 0,
+    Family,
+    Group,
+    Community,
+    World,
+}
+
+pub struct MeshScopeManager {}
+
+impl MeshScopeManager {
+    pub fn new() -> Self { Self {} }
+
+    pub fn get_node_scope_level() -> Scope {
+        // TODO: Logic to determine node's current scope
+        Scope::Personal // Dummy
+    }
+
+    pub fn update_scope_level(new_scope: Scope) -> bool {
+        // TODO: Implement protocol for scope transitions (e.g., based on WAU)
+        true // Dummy
+    }
+
+    pub fn get_gossip_range(scope: Scope) -> usize {
+        match scope {
+            Scope::Personal => 8,  // Example: 8-bit Personal mesh
+            Scope::Family => 16, // Example: 16-bit Family mesh
+            _ => 128, // Default for higher scopes
+        }
+    }
+}

--- a/src/mesh_trust_calculator.rs
+++ b/src/mesh_trust_calculator.rs
@@ -1,0 +1,49 @@
+//! mesh_trust_calculator.rs
+//! Implements Peer Review / Gossip based distributed trust score calculation.
+//! Handles WAU (Who Are You) authentication and Sybil attack resistance.
+
+pub struct TrustScoreCalculator {}
+
+impl TrustScoreCalculator {
+    pub fn new() -> Self { Self {} }
+
+    pub fn calculate_trust_score(
+        self_trust: f64,
+        peer_scores: &[f64],
+        gossip_agreement: f64,
+        scope: Scope,
+    ) -> f64 {
+        let weight_self = 0.4;
+        let weight_peer = 0.4;
+        let weight_gossip = 0.2;
+        let min_peer_reviews = match scope {
+            Scope::Personal => 1, // Only self-assessment needed
+            Scope::Family => 3,   // Needs 3 peer reviews
+            _ => 5, // Default for higher scopes
+        };
+
+        let peer_avg: f64 = if peer_scores.is_empty() { 0.0 } else { peer_scores.iter().sum::<f64>() / peer_scores.len() as f64 };
+
+        let mut trust_score = (weight_self * self_trust) +
+                              (weight_peer * peer_avg) +
+                              (weight_gossip * gossip_agreement);
+
+        // Sybil attack resistance: Halve trust if insufficient peer reviews
+        if peer_scores.len() < min_peer_reviews {
+            trust_score *= 0.5;
+        }
+
+        trust_score.clamp(0.0, 1.0)
+    }
+
+    pub fn verify_wa_u(trust_score: f64, scope: Scope) -> bool {
+        let required_threshold = match scope {
+            Scope::Personal => 0.25,
+            Scope::Family => 0.50,
+            Scope::Group => 0.75,
+            Scope::Community => 0.90,
+            Scope::World => 0.99,
+        };
+        trust_score >= required_threshold
+    }
+}


### PR DESCRIPTION
## Summary
- outline mesh network layered architecture in new RFC
- implement basic mesh modules for address allocation, scope management and trust calculation
- update work results log

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873b15a93848333b28603dd4c0bbea0