### PR TITLE
Add Rust CI workflow

### DIFF
--- a/.github/workflows/mesh_rust_ci.yml
+++ b/.github/workflows/mesh_rust_ci.yml
@@ -1,0 +1,22 @@
+name: Mesh Rust CI
+
+on:
+  push:
+    paths-ignore:
+      - 'archive/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Build workspace
+        run: cargo build --workspace --all-targets
+      - name: Run tests
+        run: cargo test --workspace


### PR DESCRIPTION
## Summary
- add `mesh_rust_ci.yml` to build and test Rust code on push

## Testing
- `cargo build --workspace --all-targets` *(fails: failed to read `KAIRO/rust-core/Cargo.toml`)*
- `cargo test --workspace` *(fails: failed to read `KAIRO/rust-core/Cargo.toml`)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873e55a7a888333b0c33d18f4f17fed