### PR TITLE
Add Rust trust and scope manager tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
 members = [
     "src/api_server",
-    "KAIRO/rust-core",
+    "archive/kairo_rust_core_legacy/rust-core",
 ]

--- a/archive/kairo_rust_core_legacy/rust-core/tests/scope_manager_test.rs
+++ b/archive/kairo_rust_core_legacy/rust-core/tests/scope_manager_test.rs
@@ -1,0 +1,15 @@
+#[path = "../../../../src/mesh_scope_manager.rs"]
+mod mesh_scope_manager;
+use mesh_scope_manager::{MeshScopeManager, Scope};
+
+#[test]
+fn promotes_scope_when_threshold_met() {
+    let next = MeshScopeManager::update_scope_level(0.85, Scope::Personal);
+    assert_eq!(next, Some(Scope::Family));
+}
+
+#[test]
+fn demotes_scope_when_below_threshold() {
+    let next = MeshScopeManager::update_scope_level(0.3, Scope::Family);
+    assert_eq!(next, Some(Scope::Personal));
+}

--- a/archive/kairo_rust_core_legacy/rust-core/tests/trust_calculator_test.rs
+++ b/archive/kairo_rust_core_legacy/rust-core/tests/trust_calculator_test.rs
@@ -1,0 +1,25 @@
+#[path = "../../../../src/mesh_trust_calculator.rs"]
+mod mesh_trust_calculator;
+use mesh_trust_calculator::{TrustScoreCalculator, Scope};
+
+#[test]
+fn calculates_trust_score_correctly() {
+    let score = TrustScoreCalculator::calculate_trust_score(
+        0.6,
+        &[0.8],
+        0.7,
+        Scope::Personal,
+    );
+    assert!((score - 0.7).abs() < f64::EPSILON);
+}
+
+#[test]
+fn applies_sybil_penalty_when_peer_reviews_insufficient() {
+    let score = TrustScoreCalculator::calculate_trust_score(
+        0.6,
+        &[0.8, 0.7],
+        0.9,
+        Scope::Group,
+    );
+    assert!((score - 0.36).abs() < f64::EPSILON);
+}

--- a/src/api_server/Cargo.toml
+++ b/src/api_server/Cargo.toml
@@ -12,4 +12,4 @@ axum = "0.7"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 bytes = "1.0"
-kairo_rust_core = { path = "../../KAIRO/rust-core", version = "0.1.0" }
+kairo_rust_core = { path = "../../archive/kairo_rust_core_legacy/rust-core", version = "0.1.0" }


### PR DESCRIPTION
## Summary
- wire up workspace to archived `kairo_rust_core` crate so it builds offline
- add integration tests for trust score calculation and sybil penalty
- add tests for scope level promotions and demotions

## Testing
- `cargo test --workspace --quiet` *(fails: failed to download crates due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6873e5598cd08333b7f532b69261f929