### PR TITLE
Add mesh trust and seed recovery RFCs

### DIFF
--- a/docs/AI-TCP_Structure/index.md
+++ b/docs/AI-TCP_Structure/index.md
@@ -6,6 +6,15 @@
 - [002 LLM Compliance](../docs/rfc_drafts/002_llm_compliance.md)
 - [003 Packet Structure](../docs/rfc_drafts/003_packet_definition.md)
 
+## 🗺 Mesh RFCs
+- [Mesh Core](../docs/RFC/AI-TCP_RFC_core.md)
+- [Mesh Network](../docs/RFC/AI-TCP_RFC_mesh_network.md)
+- [Layered Architecture](../docs/RFC/AI-TCP_RFC_mesh_layered_architecture.md)
+- [Security](../docs/RFC/AI-TCP_RFC_security.md)
+- [Trust Algorithm](../docs/RFC/AI-TCP_RFC_mesh_trust_algorithm.md)
+- [Scope Transitions](../docs/RFC/AI-TCP_RFC_scope_transitions.md)
+- [Seed Recovery](../docs/RFC/AI-TCP_RFC_seed_recovery.md)
+
 ## 📦 Graph Payload
 - [Graph Usage Guide](../docs/graph_payload_usage.md)
 - [Sample YAMLs (dmc_sessions)](../dmc_sessions/)

--- a/docs/RFC/AI-TCP_RFC_mesh_trust_algorithm.md
+++ b/docs/RFC/AI-TCP_RFC_mesh_trust_algorithm.md
@@ -1,0 +1,26 @@
+# AI-TCP Mesh Trust Algorithm RFC
+
+This RFC describes how nodes calculate distributed trust scores across the mesh network. The reference implementation lives in `src/mesh_trust_calculator.rs`.
+
+## Distributed Score Calculation
+
+Each node combines its own self score, peer feedback and observed gossip agreement:
+
+```rust
+// src/mesh_trust_calculator.rs
+let weight_self = 0.4;
+let weight_peer = 0.4;
+let weight_gossip = 0.2;
+let peer_avg = peer_scores.iter().sum::<f64>() / peer_scores.len() as f64;
+let mut trust_score = (weight_self * self_trust)
+                    + (weight_peer * peer_avg)
+                    + (weight_gossip * gossip_agreement);
+```
+
+## Sybil Resistance & Peer Review
+
+A minimum number of peer reviews is required per scope. If not met, the trust score is halved to reduce influence from potential Sybil nodes.
+
+## Hysteresis Handling
+
+`mesh_scope_manager.rs` applies hysteresis so scope changes only occur after the score remains above or below thresholds for several cycles. Trust computation should therefore retain recent history rather than react immediately.

--- a/docs/RFC/AI-TCP_RFC_scope_transitions.md
+++ b/docs/RFC/AI-TCP_RFC_scope_transitions.md
@@ -1,0 +1,18 @@
+# AI-TCP Scope Transition RFC
+
+This RFC defines how a node moves between Personal, Family, Group, Community and World scopes. Implementation details reside in `src/mesh_scope_manager.rs`.
+
+## Trust Score Thresholds
+
+```
+Personal -> Family   : >= 0.8
+Family   -> Group    : >= 0.85
+Group    -> Community: >= 0.9
+Community-> World    : >= 0.95
+```
+
+Demotions occur when the score drops well below the same thresholds.
+
+## Hysteresis Rules
+
+Scope updates only trigger if a threshold is met for multiple cycles. The manager stores recent scores to avoid oscillation. See the `update_scope_level` logic for examples of promotion and demotion checks.

--- a/docs/RFC/AI-TCP_RFC_seed_recovery.md
+++ b/docs/RFC/AI-TCP_RFC_seed_recovery.md
@@ -1,0 +1,12 @@
+# AI-TCP Seed Node Recovery RFC
+
+When all seed nodes become unreachable, isolated peers attempt recovery using cached trust data. The helper `restore_from_cache` in `src/mesh_address_allocator.rs` illustrates this flow.
+
+## Fallback Flow
+
+1. Read the local trusted peers cache.
+2. Verify cached peers via self-signed WAU.
+3. Promote a verifiable peer as a temporary seed.
+4. Rebuild DHT and gossip tables from that peer.
+
+This mechanism allows the mesh to survive extended outages without centralized coordination.


### PR DESCRIPTION
## Summary
- document mesh trust algorithm and sybil resistance
- detail scope transition rules and hysteresis
- outline seed node recovery using cached peers
- list all mesh RFCs in the project index

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873e55821e08333b5ed1cbb99a330ec