### PR TITLE
Fix duplicate Scope enum

### DIFF
--- a/src/mesh_trust_calculator.rs
+++ b/src/mesh_trust_calculator.rs
@@ -2,7 +2,6 @@
 //! Implements Peer Review / Gossip based distributed trust score calculation.
 //! Handles WAU (Who Are You) authentication and Sybil attack resistance.
 
-pub enum Scope { /* Re-declare or import Scope from mesh_scope_manager.rs */ }
 
 // Temporarily define Scope here to avoid circular dependency in initial generation
 #[allow(dead_code)]


### PR DESCRIPTION
## Summary
- remove placeholder Scope enum declaration from `mesh_trust_calculator.rs`
- run `cargo check` to verify compilation

## Testing
- `cargo check` *(fails: failed to load manifest for workspace member `/workspace/AI-TCP/src/api_server`)*

------
https://chatgpt.com/codex/tasks/task_e_6873e55777f88333b467f8356ff82f0f